### PR TITLE
Add task AppIntents

### DIFF
--- a/Intents/Task/AddTaskIntent.swift
+++ b/Intents/Task/AddTaskIntent.swift
@@ -1,0 +1,43 @@
+//
+//  AddTaskIntent.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import AppIntents
+
+@available(iOS 19, macOS 15, *)
+@AppIntent("Add a task to Wishle")
+struct AddTaskIntent {
+    static var title: LocalizedStringResource = "Add Task"
+
+    /// Service injected from the application context.
+    var service: TaskServiceProtocol = TaskService.shared
+
+    @Parameter(title: "Title")
+    var title: String
+
+    @Parameter(title: "Notes")
+    var notes: String?
+
+    @Parameter(title: "Due Date")
+    var dueDate: Date?
+
+    @Parameter(title: "Priority", default: 0)
+    var priority: Int
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add \(\.$title)") {
+            \.$notes
+            \.$dueDate
+            \.$priority
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        _ = try await service.addTask(title: title, notes: notes, dueDate: dueDate, priority: priority)
+        return .result()
+    }
+}
+

--- a/Intents/Task/DeleteTaskIntent.swift
+++ b/Intents/Task/DeleteTaskIntent.swift
@@ -1,0 +1,33 @@
+//
+//  DeleteTaskIntent.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import AppIntents
+
+@available(iOS 19, macOS 15, *)
+@AppIntent("Delete a task from Wishle")
+struct DeleteTaskIntent {
+    static var title: LocalizedStringResource = "Delete Task"
+
+    /// Service injected from the application context.
+    var service: TaskServiceProtocol = TaskService.shared
+
+    @Parameter(title: "ID")
+    var id: UUID
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Delete task \(\.$id)")
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard let task = service.task(id: id) else {
+            return .result(value: .init())
+        }
+        try await service.deleteTask(task)
+        return .result()
+    }
+}
+

--- a/Intents/Task/UpdateTaskIntent.swift
+++ b/Intents/Task/UpdateTaskIntent.swift
@@ -1,0 +1,59 @@
+//
+//  UpdateTaskIntent.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import AppIntents
+
+@available(iOS 19, macOS 15, *)
+@AppIntent("Update a task in Wishle")
+struct UpdateTaskIntent {
+    static var title: LocalizedStringResource = "Update Task"
+
+    /// Service injected from the application context.
+    var service: TaskServiceProtocol = TaskService.shared
+
+    @Parameter(title: "ID")
+    var id: UUID
+
+    @Parameter(title: "Title")
+    var title: String?
+
+    @Parameter(title: "Notes")
+    var notes: String?
+
+    @Parameter(title: "Due Date")
+    var dueDate: Date?
+
+    @Parameter(title: "Is Completed")
+    var isCompleted: Bool?
+
+    @Parameter(title: "Priority")
+    var priority: Int?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Update task \(\.$id)") {
+            \.$title
+            \.$notes
+            \.$dueDate
+            \.$isCompleted
+            \.$priority
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard let task = service.task(id: id) else {
+            return .result(value: .init())
+        }
+        if let title { task.title = title }
+        if let notes { task.notes = notes }
+        if let dueDate { task.dueDate = dueDate }
+        if let isCompleted { task.isCompleted = isCompleted }
+        if let priority { task.priority = priority }
+        try await service.updateTask(task)
+        return .result()
+    }
+}
+

--- a/Services/TaskService.swift
+++ b/Services/TaskService.swift
@@ -1,0 +1,75 @@
+//
+//  TaskService.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import Foundation
+import SwiftData
+
+/// A protocol that defines operations for managing `Task` instances.
+protocol TaskServiceProtocol {
+    /// Adds a new task and persists it.
+    /// - Returns: The created task instance.
+    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Task
+
+    /// Finds a task for the given identifier.
+    func task(id: UUID) -> Task?
+
+    /// Persists updates to the provided task.
+    func updateTask(_ task: Task) async throws
+
+    /// Deletes the task from persistence.
+    func deleteTask(_ task: Task) async throws
+}
+
+/// Default implementation of ``TaskServiceProtocol`` using SwiftData.
+@MainActor
+final class TaskService: TaskServiceProtocol {
+    /// Shared singleton instance used when no dependency is injected.
+    static var shared: TaskService = {
+        do {
+            let schema = Schema([
+                Task.self,
+                Tag.self,
+            ])
+            let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+            let container = try ModelContainer(for: schema, configurations: [configuration])
+            return .init(modelContext: container.mainContext)
+        } catch {
+            fatalError("Could not create ModelContainer: \(error)")
+        }
+    }()
+
+    /// The underlying SwiftData context.
+    private let modelContext: ModelContext
+
+    /// Creates an instance with the given model context.
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func task(id: UUID) -> Task? {
+        let descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Task {
+        let task = Task(title: title, notes: notes, dueDate: dueDate, priority: priority)
+        modelContext.insert(task)
+        try modelContext.save()
+        return task
+    }
+
+    func updateTask(_ task: Task) async throws {
+        task.updatedAt = .now
+        try modelContext.save()
+    }
+
+    func deleteTask(_ task: Task) async throws {
+        modelContext.delete(task)
+        try modelContext.save()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `TaskService` with async SwiftData operations
- add `AddTaskIntent`, `UpdateTaskIntent`, and `DeleteTaskIntent`

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851852a7a5483208a206af7aa2563c1