### PR TITLE
Add Next Up widget

### DIFF
--- a/Widgets/NextUp/NextUpWidget.swift
+++ b/Widgets/NextUp/NextUpWidget.swift
@@ -1,0 +1,86 @@
+//
+//  NextUpWidget.swift
+//  WishleWidget
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct NextUpProvider: TimelineProvider {
+    func placeholder(in _: Context) -> NextUpEntry {
+        .init(date: .now, task: .placeholder)
+    }
+
+    func getSnapshot(in _: Context, completion: @escaping (NextUpEntry) -> Void) {
+        completion(.init(date: .now, task: .placeholder))
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<NextUpEntry>) -> Void) {
+        let task = TaskService.shared.nextUpTask()
+        let entry = NextUpEntry(date: .now, task: task)
+        let timeline = Timeline(entries: [entry], policy: .after(.now.advanced(by: 60 * 15)))
+        completion(timeline)
+    }
+}
+
+struct NextUpEntry: TimelineEntry {
+    let date: Date
+    let task: Task?
+}
+
+struct NextUpWidgetEntryView: View {
+    var entry: NextUpProvider.Entry
+    @Environment(\.widgetFamily) private var widgetFamily
+
+    var body: some View {
+        switch widgetFamily {
+        case .accessoryInline:
+            content
+        default:
+            content
+                .padding()
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading) {
+            if let task = entry.task {
+                Text(task.title)
+                    .font(.headline)
+                if let dueDate = task.dueDate {
+                    Text(dueDate, style: .date)
+                        .font(.caption)
+                }
+            } else {
+                Text("No tasks")
+            }
+        }
+    }
+}
+
+struct NextUpWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "NextUpWidget", provider: NextUpProvider()) { entry in
+            NextUpWidgetEntryView(entry: entry)
+        }
+        .supportedFamilies([.systemSmall, .accessoryInline])
+        .configurationDisplayName("Next Up")
+        .description("Shows your next uncompleted task")
+    }
+}
+
+extension Task {
+    fileprivate static var placeholder: Task {
+        .init(title: "Sample", notes: nil, dueDate: .now.addingTimeInterval(3600), priority: 0)
+    }
+}
+
+#if DEBUG
+#Preview(as: .systemSmall) {
+    NextUpWidget()
+} timeline: {
+    NextUpEntry(date: .now, task: .placeholder)
+}
+#endif

--- a/Widgets/NextUp/NextUpWidgetLiveActivity.swift
+++ b/Widgets/NextUp/NextUpWidgetLiveActivity.swift
@@ -1,0 +1,56 @@
+//
+//  NextUpWidgetLiveActivity.swift
+//  WishleWidget
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct NextUpAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var taskId: UUID
+    }
+
+    var name: String
+}
+
+struct NextUpWidgetLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: NextUpAttributes.self) { context in
+            VStack {
+                Text("Next: \(context.state.taskId.uuidString.prefix(4))")
+            }
+        } dynamicIsland: { _ in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.center) {
+                    Text("Next Up")
+                }
+            } compactLeading: {
+                Text("Next")
+            } compactTrailing: {
+                Text("Up")
+            } minimal: {
+                Text("🎯")
+            }
+        }
+    }
+}
+
+extension NextUpAttributes {
+    fileprivate static var preview: NextUpAttributes { .init(name: "Preview") }
+}
+
+extension NextUpAttributes.ContentState {
+    fileprivate static var sample: NextUpAttributes.ContentState { .init(taskId: .init()) }
+}
+
+#if DEBUG
+#Preview("Notification", as: .content, using: NextUpAttributes.preview) {
+    NextUpWidgetLiveActivity()
+} contentStates: {
+    NextUpAttributes.ContentState.sample
+}
+#endif

--- a/WishleWidget/WishleWidgetBundle.swift
+++ b/WishleWidget/WishleWidgetBundle.swift
@@ -12,7 +12,9 @@ import WidgetKit
 struct WishleWidgetBundle: WidgetBundle {
     var body: some Widget {
         WishleWidget()
+        NextUpWidget()
         WishleWidgetControl()
         WishleWidgetLiveActivity()
+        NextUpWidgetLiveActivity()
     }
 }


### PR DESCRIPTION
## Summary
- implement method to fetch the next uncompleted task
- add `NextUpWidget` and live activity scaffolding
- register the new widget in `WishleWidgetBundle`

## Testing
- `swift build -c release` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685186b4ce488320979796e3869bfd7c