### PR TITLE
Fix NextUpWidget build issues

### DIFF
--- a/WishleWidget/NextUp/NextUpWidget.swift
+++ b/WishleWidget/NextUp/NextUpWidget.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WidgetKit
+import Foundation
 
 struct NextUpProvider: TimelineProvider {
     func placeholder(in _: Context) -> NextUpEntry {
@@ -18,7 +19,7 @@ struct NextUpProvider: TimelineProvider {
     }
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<NextUpEntry>) -> Void) {
-        let task = TaskService.shared.nextUpTask()
+        let task = TaskDataStore.shared.nextUpTask()
         let entry = NextUpEntry(date: .now, task: task)
         let timeline = Timeline(entries: [entry], policy: .after(.now.advanced(by: 60 * 15)))
         completion(timeline)
@@ -27,7 +28,7 @@ struct NextUpProvider: TimelineProvider {
 
 struct NextUpEntry: TimelineEntry {
     let date: Date
-    let task: Task?
+    let task: WidgetTask?
 }
 
 struct NextUpWidgetEntryView: View {
@@ -71,9 +72,9 @@ struct NextUpWidget: Widget {
     }
 }
 
-extension Task {
-    fileprivate static var placeholder: Task {
-        .init(title: "Sample", notes: nil, dueDate: .now.addingTimeInterval(3_600), priority: 0)
+extension WidgetTask {
+    static var placeholder: WidgetTask {
+        .init(id: .init(), title: "Sample", dueDate: .now.addingTimeInterval(3_600), priority: 0)
     }
 }
 

--- a/WishleWidget/NextUp/TaskDataStore.swift
+++ b/WishleWidget/NextUp/TaskDataStore.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct TaskDataStore {
+    static let shared = TaskDataStore()
+
+    private let defaults = UserDefaults(suiteName: "group.com.muhiro12.wishle")
+    private let key = "nextUpTask"
+
+    func nextUpTask() -> WidgetTask? {
+        guard let defaults, let data = defaults.data(forKey: key) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(WidgetTask.self, from: data)
+    }
+}

--- a/WishleWidget/NextUp/WidgetTask.swift
+++ b/WishleWidget/NextUp/WidgetTask.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct WidgetTask: Identifiable, Codable, Hashable {
+    var id: UUID
+    var title: String
+    var dueDate: Date?
+    var priority: Int
+}
+
+extension WidgetTask {
+    static var placeholder: WidgetTask {
+        .init(id: .init(), title: "Sample", dueDate: .now.addingTimeInterval(3_600), priority: 0)
+    }
+}


### PR DESCRIPTION
## Summary
- remove reference to `TaskService` from NextUp widget
- add `WidgetTask` model and `TaskDataStore` for shared user defaults

## Testing
- `pre-commit run --files WishleWidget/NextUp/NextUpWidget.swift WishleWidget/NextUp/WidgetTask.swift WishleWidget/NextUp/TaskDataStore.swift` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_685188c0552083208d5328b9839aeee0