### PR TITLE
Implement forced update support

### DIFF
--- a/.config.json
+++ b/.config.json
@@ -1,0 +1,3 @@
+{
+  "requiredVersion": "1.0"
+}

--- a/Wishle/ContentView.swift
+++ b/Wishle/ContentView.swift
@@ -7,10 +7,16 @@
 
 import SwiftUI
 import SwiftData
+#if os(iOS)
+import UIKit
+#endif
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var items: [Item]
+
+    @StateObject private var configurationService = ConfigurationService.shared
+    @State private var isUpdateAlertPresented = false
 
     var body: some View {
         NavigationSplitView {
@@ -41,6 +47,23 @@ struct ContentView: View {
             }
         } detail: {
             Text("Select an item")
+        }
+        .alert(Text("Update Required"), isPresented: $isUpdateAlertPresented) {
+            Button {
+                #if os(iOS)
+                UIApplication.shared.open(
+                    URL(string: "https://apps.apple.com/jp/app/id000000000")!
+                )
+                #endif
+            } label: {
+                Text("Open App Store")
+            }
+        } message: {
+            Text("Please update Wishle to the latest version to continue using it.")
+        }
+        .task {
+            try? await configurationService.load()
+            isUpdateAlertPresented = configurationService.isUpdateRequired()
         }
     }
 

--- a/Wishle/Models/Configuration.swift
+++ b/Wishle/Models/Configuration.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct Configuration: Decodable {
+    let requiredVersion: String
+}

--- a/Wishle/Services/ConfigurationService.swift
+++ b/Wishle/Services/ConfigurationService.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+@MainActor
+final class ConfigurationService: ObservableObject {
+    static let shared = ConfigurationService()
+
+    private(set) var configuration: Configuration?
+    private let decoder = JSONDecoder()
+
+    private init() {}
+
+    func load() async throws {
+        let url = URL(string: "https://raw.githubusercontent.com/muhiro12/Wishle/main/.config.json")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        configuration = try decoder.decode(Configuration.self, from: data)
+    }
+
+    func isUpdateRequired() -> Bool {
+        guard let current = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              let required = configuration?.requiredVersion,
+              Bundle.main.bundleIdentifier?.contains("playgrounds") == false else {
+            return false
+        }
+        return current.compare(required, options: .numeric) == .orderedAscending
+    }
+}


### PR DESCRIPTION
## Summary
- add remote config parsing
- load remote config at launch and show forced-update alert if necessary

## Testing
- `swiftlint` *(fails: command not found)*
- `xcodebuild -list -project Wishle.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518ed26d048320b3668a8486f79f8e