### PR TITLE
Implement onboarding flow

### DIFF
--- a/Wishle/OnboardingFlow.swift
+++ b/Wishle/OnboardingFlow.swift
@@ -1,0 +1,82 @@
+//
+//  OnboardingFlow.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/18.
+//
+
+import SwiftUI
+import TipKit
+
+struct SwipeToCompleteTip: Tip {
+    var title: Text {
+        "Swipe to complete"
+    }
+    var message: Text? {
+        "Swipe a task to mark it completed."
+    }
+}
+
+struct LongPressQuickEditTip: Tip {
+    var title: Text {
+        "Long-press for quick edit"
+    }
+    var message: Text? {
+        "Long press on a task to edit it."
+    }
+}
+
+struct OnboardingFlow: View {
+    @State private var selection = 0
+    @Environment(\.dismiss) private var dismiss
+
+    private let swipeTip: SwipeToCompleteTip = .init()
+    private let editTip: LongPressQuickEditTip = .init()
+
+    var body: some View {
+        TabView(selection: $selection) {
+            page(title: "Welcome to Wishle", description: "Store what you wish to do, not what you must do.") {
+                Button("Next") { selection = 1 }
+            }
+            .tag(0)
+
+            page(title: nil, description: nil) {
+                TipView(swipeTip)
+                Button("Next") { selection = 2 }
+            }
+            .tag(1)
+
+            page(title: nil, description: nil) {
+                TipView(editTip)
+                Button("Get Started") { finish() }
+            }
+            .tag(2)
+        }
+        .tabViewStyle(.page)
+    }
+
+    private func page(title: String?, description: String?, @ViewBuilder content: () -> some View) -> some View {
+        VStack(spacing: 20) {
+            Spacer()
+            if let title {
+                Text(title)
+                    .font(.largeTitle)
+            }
+            if let description {
+                Text(description)
+            }
+            content()
+            Spacer()
+        }
+        .padding()
+    }
+
+    private func finish() {
+        UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
+        dismiss()
+    }
+}
+
+#Preview {
+    OnboardingFlow()
+}

--- a/Wishle/WishleApp.swift
+++ b/Wishle/WishleApp.swift
@@ -25,7 +25,11 @@ struct WishleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
+                ContentView()
+            } else {
+                OnboardingFlow()
+            }
         }
         .modelContainer(sharedModelContainer)
     }


### PR DESCRIPTION
## Summary
- add onboarding flow with two TipKit tips
- show onboarding on first launch only

## Testing
- `pre-commit` *(fails: error: RPC failed; HTTP 403)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68519365b46c8320a90a356f0ecf43a1