### PR TITLE
Add Reminders import/export services

### DIFF
--- a/Wishle/Intents/Reminders/ImportRemindersIntent.swift
+++ b/Wishle/Intents/Reminders/ImportRemindersIntent.swift
@@ -1,0 +1,19 @@
+//
+//  ImportRemindersIntent.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import AppIntents
+
+struct ImportRemindersIntent: AppIntent {
+    static var title: LocalizedStringResource = "Import Reminders"
+
+    var importer: RemindersImporter = .init()
+
+    func perform() async throws -> some IntentResult {
+        try await importer.import()
+        return .result()
+    }
+}

--- a/Wishle/Services/RemindersExporter.swift
+++ b/Wishle/Services/RemindersExporter.swift
@@ -1,0 +1,78 @@
+//
+//  RemindersExporter.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import EventKit
+import SwiftData
+
+@MainActor
+struct RemindersExporter {
+    private let eventStore: EKEventStore
+    private let service: TaskServiceProtocol
+
+    init(eventStore: EKEventStore = .init(),
+         service: TaskServiceProtocol = TaskService.shared) {
+        self.eventStore = eventStore
+        self.service = service
+    }
+
+    func export() async throws {
+        try await eventStore.requestFullAccessToReminders()
+        let tasks = try service.context.fetch(FetchDescriptor<Task>())
+        for task in tasks {
+            for tag in task.tags {
+                let calendar = try fetchOrCreateCalendar(name: tag.name)
+                if let reminder = try await findReminder(for: task, in: calendar) {
+                    let lastModified = reminder.lastModifiedDate ?? .distantPast
+                    if task.updatedAt > lastModified {
+                        update(reminder: reminder, from: task, calendar: calendar)
+                        try eventStore.save(reminder, commit: false)
+                    }
+                } else {
+                    let reminder = EKReminder(eventStore: eventStore)
+                    update(reminder: reminder, from: task, calendar: calendar)
+                    try eventStore.save(reminder, commit: false)
+                }
+            }
+        }
+        try eventStore.commit()
+    }
+
+    private func fetchOrCreateCalendar(name: String) throws -> EKCalendar {
+        if let calendar = eventStore.calendars(for: .reminder).first(where: { $0.title == name }) {
+            return calendar
+        }
+        let calendar = EKCalendar(for: .reminder, eventStore: eventStore)
+        calendar.title = name
+        calendar.source = eventStore.defaultCalendarForNewReminders()?.source
+            ?? eventStore.defaultCalendarForNewEvents().source
+        try eventStore.saveCalendar(calendar, commit: false)
+        return calendar
+    }
+
+    private func findReminder(for task: Task, in calendar: EKCalendar) async throws -> EKReminder? {
+        let predicate = eventStore.predicateForReminders(in: [calendar])
+        let reminders = try await eventStore.fetchReminders(matching: predicate)
+        return reminders.first { reminder in
+            reminder.title == task.title && reminder.dueDateComponents?.date == task.dueDate
+        }
+    }
+
+    private func update(reminder: EKReminder, from task: Task, calendar: EKCalendar) {
+        reminder.calendar = calendar
+        reminder.title = task.title
+        reminder.notes = task.notes
+        reminder.priority = Int16(task.priority)
+        if let dueDate = task.dueDate {
+            reminder.dueDateComponents = Calendar.current.dateComponents([
+                .year, .month, .day, .hour, .minute
+            ], from: dueDate)
+        } else {
+            reminder.dueDateComponents = nil
+        }
+        reminder.isCompleted = task.isCompleted
+    }
+}

--- a/Wishle/Services/RemindersImporter.swift
+++ b/Wishle/Services/RemindersImporter.swift
@@ -1,0 +1,75 @@
+//
+//  RemindersImporter.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import EventKit
+import SwiftData
+
+@MainActor
+struct RemindersImporter {
+    private let eventStore: EKEventStore
+    private let service: TaskServiceProtocol
+
+    init(eventStore: EKEventStore = .init(),
+         service: TaskServiceProtocol = TaskService.shared) {
+        self.eventStore = eventStore
+        self.service = service
+    }
+
+    func `import`() async throws {
+        try await eventStore.requestFullAccessToReminders()
+        let calendars = eventStore.calendars(for: .reminder)
+        for calendar in calendars {
+            let tag = try fetchOrCreateTag(name: calendar.title)
+            let predicate = eventStore.predicateForReminders(in: [calendar])
+            let reminders = try await eventStore.fetchReminders(matching: predicate)
+            for reminder in reminders {
+                guard let title = reminder.title else { continue }
+                let dueDate = reminder.dueDateComponents?.date
+                let notes = reminder.notes
+                let priority = Int(reminder.priority)
+                if let existing = try findTask(for: reminder, tag: tag) {
+                    if let lastModified = reminder.lastModifiedDate,
+                       lastModified > existing.updatedAt {
+                        existing.title = title
+                        existing.notes = notes
+                        existing.dueDate = dueDate
+                        existing.isCompleted = reminder.isCompleted
+                        existing.priority = priority
+                        try service.updateTask(existing)
+                    }
+                } else {
+                    var task = try service.addTask(title: title,
+                                                   notes: notes,
+                                                   dueDate: dueDate,
+                                                   priority: priority)
+                    task.isCompleted = reminder.isCompleted
+                    task.tags.append(tag)
+                    try service.updateTask(task)
+                }
+            }
+        }
+    }
+
+    private func fetchOrCreateTag(name: String) throws -> Tag {
+        let descriptor = FetchDescriptor<Tag>(predicate: #Predicate { $0.name == name.lowercased() })
+        if let tag = try service.context.fetch(descriptor).first {
+            return tag
+        }
+        let tag = Tag(name: name)
+        service.context.insert(tag)
+        try service.context.save()
+        return tag
+    }
+
+    private func findTask(for reminder: EKReminder, tag: Tag) throws -> Task? {
+        guard let title = reminder.title else { return nil }
+        let descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.title == title })
+        guard let tasks = try service.context.fetch(descriptor) as [Task]? else { return nil }
+        let dueDate = reminder.dueDateComponents?.date
+        return tasks.first { $0.dueDate == dueDate && $0.tags.contains(tag) }
+    }
+}

--- a/Wishle/Services/TaskService.swift
+++ b/Wishle/Services/TaskService.swift
@@ -25,6 +25,9 @@ protocol TaskServiceProtocol {
 
     /// Returns the next task that is not completed, ordered by due date then priority.
     func nextUpTask() -> Task?
+
+    /// Underlying SwiftData context for advanced operations.
+    var context: ModelContext { get }
 }
 
 /// Default implementation of ``TaskServiceProtocol`` using SwiftData.
@@ -47,6 +50,9 @@ final class TaskService: TaskServiceProtocol {
 
     /// The underlying SwiftData context.
     private let modelContext: ModelContext
+
+    /// Exposes the underlying context for advanced operations.
+    var context: ModelContext { modelContext }
 
     /// Creates an instance with the given model context.
     init(modelContext: ModelContext) {


### PR DESCRIPTION
## Summary
- expose TaskService context for other services
- add RemindersImporter and RemindersExporter using EventKit
- add ImportRemindersIntent for one-tap import

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519381d9dc8320891727f4644ced60