### PR TITLE
Fix onboarding state storage

### DIFF
--- a/Wishle/OnboardingFlow.swift
+++ b/Wishle/OnboardingFlow.swift
@@ -29,6 +29,7 @@ struct LongPressQuickEditTip: Tip {
 struct OnboardingFlow: View {
     @State private var selection = 0
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
 
     private let swipeTip: SwipeToCompleteTip = .init()
     private let editTip: LongPressQuickEditTip = .init()
@@ -72,7 +73,7 @@ struct OnboardingFlow: View {
     }
 
     private func finish() {
-        UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
+        hasSeenOnboarding = true
         dismiss()
     }
 }


### PR DESCRIPTION
## Summary
- persist onboarding state with `@AppStorage`

## Testing
- `swift test` *(fails: no such module 'StoreKit')*

------
https://chatgpt.com/codex/tasks/task_e_6851a03d96dc8320b1acd2242b1b444f