### PR TITLE
Rename model to Wish

### DIFF
--- a/Prompts/suggestion_template.txt
+++ b/Prompts/suggestion_template.txt
@@ -1,4 +1,4 @@
-# Wishle Task Suggestions
-You are Wishle's on-device AI assistant. Based on the provided context, suggest up to three tasks the user might enjoy accomplishing. Only respond with a JSON array of objects using `title` and optional `notes` fields.
+# Wishle Wish Suggestions
+You are Wishle's on-device AI assistant. Based on the provided context, suggest up to three wishes the user might enjoy accomplishing. Only respond with a JSON array of objects using `title` and optional `notes` fields.
 Context:
 {{context}}

--- a/Wishle/Models/Tag.swift
+++ b/Wishle/Models/Tag.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftData
 
-/// A tag used to categorize tasks.
+/// A tag used to categorize wishes.
 @Model
 final class Tag: Identifiable, Hashable {
     /// Unique identifier for the tag.
@@ -23,15 +23,15 @@ final class Tag: Identifiable, Hashable {
         }
     }
 
-    /// Tasks that include this tag.
-    @Relationship(inverse: \Task.tags) var tasks: [Task] = []
+    /// Wishes that include this tag.
+    @Relationship(inverse: \Wish.tags) var wishes: [Wish] = []
 
     init(id: UUID = .init(),
          name: String,
-         tasks: [Task] = []) {
+         wishes: [Wish] = []) {
         self.id = id
         self.name = name.lowercased()
-        self.tasks = tasks
+        self.wishes = wishes
     }
 
     /// Sample tags for preview usage.

--- a/Wishle/Models/Wish.swift
+++ b/Wishle/Models/Wish.swift
@@ -1,5 +1,5 @@
 //
-//  Task.swift
+//  Wish.swift
 //  Wishle
 //
 //  Created by Hiromu Nakano on 2025/06/17.
@@ -8,18 +8,18 @@
 import Foundation
 import SwiftData
 
-/// A task item within Wishle.
+/// A wish item within Wishle.
 @Model
-final class Task: Identifiable, Hashable {
-    /// Unique identifier for the task.
+final class Wish: Identifiable, Hashable {
+    /// Unique identifier for the wish.
     @Attribute(.unique) var id: UUID
     /// The user-facing title.
     var title: String
-    /// Optional notes about the task.
+    /// Optional notes about the wish.
     var notes: String?
     /// An optional due date.
     var dueDate: Date?
-    /// Marks the task as completed.
+    /// Marks the wish as completed.
     var isCompleted: Bool
     /// Priority level (0 normal, 1 high).
     var priority: Int
@@ -28,10 +28,10 @@ final class Task: Identifiable, Hashable {
     /// Last update timestamp.
     var updatedAt: Date
 
-    /// Tags associated with the task. Removing the task deletes its tags.
+    /// Tags associated with the wish. Removing the wish deletes its tags.
     @Relationship(deleteRule: .cascade) var tags: [Tag] = []
 
-    /// Returns true when the due date has passed and the task is not completed.
+    /// Returns true when the due date has passed and the wish is not completed.
     var isOverdue: Bool {
         guard let dueDate else { return false }
         return dueDate < .now && !isCompleted

--- a/Wishle/Services/AISuggestionService.swift
+++ b/Wishle/Services/AISuggestionService.swift
@@ -32,9 +32,9 @@ final class AISuggestionService {
     }
 
     /// Generates task suggestions for the provided context.
-    func suggestTasks(for context: SuggestionContext) async throws -> [Task] {
+    func suggestTasks(for context: SuggestionContext) async throws -> [Wish] {
         let prompt = promptTemplate.replacingOccurrences(of: "{{context}}", with: context.text)
         let response = try await session.respond(to: prompt, generating: [TaskSuggestion].self)
-        return response.content.map { Task(title: $0.title, notes: $0.notes) }
+        return response.content.map { Wish(title: $0.title, notes: $0.notes) }
     }
 }

--- a/Wishle/Services/RemindersExporter.swift
+++ b/Wishle/Services/RemindersExporter.swift
@@ -21,7 +21,7 @@ struct RemindersExporter {
 
     func export() async throws {
         try await eventStore.requestFullAccessToReminders()
-        let tasks = try service.context.fetch(FetchDescriptor<Task>())
+        let tasks = try service.context.fetch(FetchDescriptor<Wish>())
         for task in tasks {
             for tag in task.tags {
                 let calendar = try fetchOrCreateCalendar(name: tag.name)
@@ -58,7 +58,7 @@ struct RemindersExporter {
         return calendar
     }
 
-    private func findReminder(for task: Task, in calendar: EKCalendar) async throws -> EKReminder? {
+    private func findReminder(for task: Wish, in calendar: EKCalendar) async throws -> EKReminder? {
         let predicate = eventStore.predicateForReminders(in: [calendar])
         let reminders: [EKReminder] = try await withCheckedThrowingContinuation { continuation in
             eventStore.fetchReminders(matching: predicate) { fetchedReminders in
@@ -74,7 +74,7 @@ struct RemindersExporter {
         }
     }
 
-    private func update(reminder: EKReminder, from task: Task, calendar: EKCalendar) {
+    private func update(reminder: EKReminder, from task: Wish, calendar: EKCalendar) {
         reminder.calendar = calendar
         reminder.title = task.title
         reminder.notes = task.notes

--- a/Wishle/Services/RemindersImporter.swift
+++ b/Wishle/Services/RemindersImporter.swift
@@ -65,9 +65,9 @@ struct RemindersImporter {
         return tag
     }
 
-    private func findTask(for reminder: EKReminder, tag: Tag) throws -> Task? {
+    private func findTask(for reminder: EKReminder, tag: Tag) throws -> Wish? {
         guard let title = reminder.title else { return nil }
-        let descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.title == title })
+        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.title == title })
         let tasks = try service.context.fetch(descriptor)
         let dueDate = reminder.dueDateComponents?.date
         return tasks.first { $0.dueDate == dueDate && $0.tags.contains(tag) }

--- a/Wishle/Services/TaskService.swift
+++ b/Wishle/Services/TaskService.swift
@@ -8,23 +8,23 @@
 import Foundation
 import SwiftData
 
-/// A protocol that defines operations for managing `Task` instances.
+/// A protocol that defines operations for managing `Wish` instances.
 protocol TaskServiceProtocol {
     /// Adds a new task and persists it.
     /// - Returns: The created task instance.
-    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Task
+    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Wish
 
     /// Finds a task for the given identifier.
-    func task(id: UUID) -> Task?
+    func task(id: UUID) -> Wish?
 
     /// Persists updates to the provided task.
-    func updateTask(_ task: Task) async throws
+    func updateTask(_ task: Wish) async throws
 
     /// Deletes the task from persistence.
-    func deleteTask(_ task: Task) async throws
+    func deleteTask(_ task: Wish) async throws
 
     /// Returns the next task that is not completed, ordered by due date then priority.
-    func nextUpTask() -> Task?
+    func nextUpTask() -> Wish?
 
     /// Underlying SwiftData context for advanced operations.
     var context: ModelContext { get }
@@ -37,7 +37,7 @@ final class TaskService: TaskServiceProtocol {
     static var shared: TaskService = {
         do {
             let schema = Schema([
-                Task.self,
+                Wish.self,
                 Tag.self
             ])
             let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
@@ -59,30 +59,30 @@ final class TaskService: TaskServiceProtocol {
         self.modelContext = modelContext
     }
 
-    func task(id: UUID) -> Task? {
-        let descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })
+    func task(id: UUID) -> Wish? {
+        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.id == id })
         return try? modelContext.fetch(descriptor).first
     }
 
-    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Task {
-        let task = Task(title: title, notes: notes, dueDate: dueDate, priority: priority)
+    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish {
+        let task = Wish(title: title, notes: notes, dueDate: dueDate, priority: priority)
         modelContext.insert(task)
         try modelContext.save()
         return task
     }
 
-    func updateTask(_ task: Task) throws {
+    func updateTask(_ task: Wish) throws {
         task.updatedAt = .now
         try modelContext.save()
     }
 
-    func deleteTask(_ task: Task) throws {
+    func deleteTask(_ task: Wish) throws {
         modelContext.delete(task)
         try modelContext.save()
     }
 
-    func nextUpTask() -> Task? {
-        let descriptor = FetchDescriptor<Task>(predicate: #Predicate { !$0.isCompleted })
+    func nextUpTask() -> Wish? {
+        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { !$0.isCompleted })
         guard let tasks = try? modelContext.fetch(descriptor) else {
             return nil
         }


### PR DESCRIPTION
## Summary
- introduce new `Wish` model to replace previous `WishTask`
- update `Tag` relationship to use `Wish` items
- adjust services and prompts to work with `Wish` objects

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a083fa28832094773c9f0959d89c