### PR TITLE
feat(ui): introduce chat-style main screen with Wish/Suggestion bubbles

### DIFF
--- a/Docs/UI/main-chat-flow.md
+++ b/Docs/UI/main-chat-flow.md
@@ -1,0 +1,18 @@
+# Main Chat Flow
+
+The main chat screen lists wishes chronologically and mixes in AI suggestions. Components are organised as follows:
+
+```mermaid
+flowchart TD
+    MC(MainChatView) -->|displays| B(ChatBubble)
+    B --> W[WishBubble]
+    B --> S[SuggestionBubble]
+    MC --> I(InputBar)
+    MC --> VM(MainChatViewModel)
+    VM --> WS[WishService]
+    VM --> AS[AISuggestionService]
+```
+
+`MainChatViewModel` loads persisted wishes via `WishService` and fetches suggestions from `AISuggestionService`. Bubbles render each item, and the `InputBar` lets users add new wishes.
+
+Use `MainChatView()` as the root view of the app.

--- a/Wishle/Assets.xcassets/WishlePrimary.colorset/Contents.json
+++ b/Wishle/Assets.xcassets/WishlePrimary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.14",
+          "green" : "0.54",
+          "blue" : "0.94",
+          "alpha" : "1.0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Wishle/Services/AISuggestionService.swift
+++ b/Wishle/Services/AISuggestionService.swift
@@ -1,6 +1,12 @@
 import Foundation
 import FoundationModels
 
+/// Protocol for services that provide wish suggestions.
+protocol AISuggestionServiceProtocol {
+    /// Generates wish suggestions for the provided context.
+    func suggestTasks(for context: SuggestionContext) async throws -> [Wish]
+}
+
 @Generable
 private struct TaskSuggestion: Decodable {
     var title: String
@@ -15,7 +21,7 @@ struct SuggestionContext: Sendable {
 
 /// Service that generates task suggestions using an on-device foundation model.
 @MainActor
-final class AISuggestionService {
+final class AISuggestionService: AISuggestionServiceProtocol {
     static let shared = AISuggestionService()
 
     private let session: LanguageModelSession

--- a/Wishle/Services/WishService.swift
+++ b/Wishle/Services/WishService.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftData
+
+/// Protocol defining operations for managing wishes.
+protocol WishServiceProtocol {
+    /// Returns all wishes.
+    func fetchWishes() throws -> [Wish]
+    /// Adds a new wish and persists it.
+    func addWish(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish
+    /// Finds a wish by identifier.
+    func wish(id: UUID) -> Wish?
+    /// Persists updates to the provided wish.
+    func updateWish(_ wish: Wish) throws
+    /// Deletes the wish from persistence.
+    func deleteWish(_ wish: Wish) throws
+    /// Returns the next wish that is not completed, ordered by due date then priority.
+    func nextUpWish() -> Wish?
+    /// Underlying SwiftData context for advanced operations.
+    var context: ModelContext { get }
+}
+
+/// Default implementation of ``WishServiceProtocol`` wrapping ``TaskService``.
+@MainActor final class WishService: WishServiceProtocol {
+    static var shared = WishService(taskService: TaskService.shared)
+
+    private let taskService: TaskServiceProtocol
+
+    init(taskService: TaskServiceProtocol) {
+        self.taskService = taskService
+    }
+
+    var context: ModelContext { taskService.context }
+
+    func fetchWishes() throws -> [Wish] {
+        try taskService.context.fetch(FetchDescriptor<Wish>())
+    }
+
+    func addWish(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish {
+        try taskService.addTask(title: title, notes: notes, dueDate: dueDate, priority: priority)
+    }
+
+    func wish(id: UUID) -> Wish? {
+        taskService.task(id: id)
+    }
+
+    func updateWish(_ wish: Wish) throws {
+        try taskService.updateTask(wish)
+    }
+
+    func deleteWish(_ wish: Wish) throws {
+        try taskService.deleteTask(wish)
+    }
+
+    func nextUpWish() -> Wish? {
+        taskService.nextUpTask()
+    }
+}

--- a/Wishle/UI/MainChat/InputBar.swift
+++ b/Wishle/UI/MainChat/InputBar.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Input bar used at the bottom of ``MainChatView``.
+struct InputBar: View {
+    @State private var text = ""
+    let onSend: (String) -> Void
+
+    var body: some View {
+        HStack {
+            TextField("New wish", text: $text)
+            Button("Send") {
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                onSend(trimmed)
+                text = ""
+            }
+            .accessibilityLabel("Send wish")
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    InputBar { _ in }
+}

--- a/Wishle/UI/MainChat/MainChatView.swift
+++ b/Wishle/UI/MainChat/MainChatView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Root chat-style timeline allowing users to manage wishes.
+struct MainChatView: View {
+    @StateObject private var viewModel = MainChatViewModel()
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
+    @State private var isOnboardingPresented = false
+    @State private var isPaywallPresented = false
+    @State private var subscriptionManager = SubscriptionManager.shared
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(viewModel.bubbles) { bubble in
+                            switch bubble {
+                            case let .wish(wish):
+                                WishBubble(wish: wish) {
+                                    Task { await viewModel.completeWish(wish) }
+                                }
+                                .id(bubble.id)
+                            case let .suggestion(suggestion):
+                                SuggestionBubble(suggestion: suggestion) {
+                                    Task { await viewModel.acceptSuggestion(suggestion) }
+                                }
+                                .id(bubble.id)
+                            }
+                        }
+                    }
+                    .padding()
+                }
+                .refreshable { await viewModel.refreshSuggestions() }
+                .onChange(of: viewModel.bubbles.count) { _, _ in
+                    if let last = viewModel.bubbles.last {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+            InputBar { title in
+                Task { await viewModel.addWish(title: title) }
+            }
+        }
+        .sheet(isPresented: $isPaywallPresented) {
+            PaywallView()
+        }
+        .fullScreenCover(isPresented: $isOnboardingPresented) {
+            OnboardingFlow()
+        }
+        .task {
+            await viewModel.load()
+            isOnboardingPresented = !hasSeenOnboarding
+            await subscriptionManager.load()
+            isPaywallPresented = !subscriptionManager.isSubscribed
+        }
+        .onChange(of: subscriptionManager.isSubscribed) { _, newValue in
+            isPaywallPresented = !newValue
+        }
+    }
+}
+
+#Preview {
+    MainChatView()
+}

--- a/Wishle/UI/MainChat/MainChatViewModel.swift
+++ b/Wishle/UI/MainChat/MainChatViewModel.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SwiftUI
+
+/// Chat bubble types shown in ``MainChatView``.
+enum ChatBubble: Identifiable, Hashable {
+    case wish(Wish)
+    case suggestion(WishSuggestion)
+
+    var id: UUID {
+        switch self {
+        case let .wish(wish):
+            return wish.id
+        case let .suggestion(suggestion):
+            return suggestion.id
+        }
+    }
+}
+
+/// A suggestion returned from ``AISuggestionService``.
+struct WishSuggestion: Identifiable, Hashable {
+    var id: UUID = .init()
+    var title: String
+    var notes: String?
+}
+
+/// View model driving ``MainChatView``.
+@MainActor final class MainChatViewModel: ObservableObject {
+    @Published var bubbles: [ChatBubble] = []
+
+    private let wishService: WishServiceProtocol
+    private let suggestionService: AISuggestionServiceProtocol
+
+    init(wishService: WishServiceProtocol = WishService.shared,
+         suggestionService: AISuggestionServiceProtocol = AISuggestionService.shared) {
+        self.wishService = wishService
+        self.suggestionService = suggestionService
+    }
+
+    /// Loads wishes and suggestions concurrently.
+    func load() async {
+        async let wishesTask = fetchWishes()
+        async let suggestionsTask = fetchSuggestions()
+        let wishes = await wishesTask
+        let suggestions = await suggestionsTask
+        bubbles = wishes.map(ChatBubble.wish) + suggestions.map(ChatBubble.suggestion)
+    }
+
+    /// Adds a new wish from the provided title.
+    func addWish(title: String) async {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard let wish = try? wishService.addWish(title: trimmed, notes: nil, dueDate: nil, priority: 0) else { return }
+        bubbles.append(.wish(wish))
+    }
+
+    /// Marks the given wish as completed.
+    func completeWish(_ wish: Wish) async {
+        wish.isCompleted = true
+        try? wishService.updateWish(wish)
+    }
+
+    /// Converts a suggestion to a persisted wish.
+    func acceptSuggestion(_ suggestion: WishSuggestion) async {
+        guard let index = bubbles.firstIndex(where: { $0.id == suggestion.id }) else { return }
+        guard let wish = try? wishService.addWish(title: suggestion.title, notes: suggestion.notes, dueDate: nil, priority: 0) else { return }
+        bubbles[index] = .wish(wish)
+    }
+
+    /// Refreshes AI suggestions.
+    func refreshSuggestions() async {
+        let suggestions = await fetchSuggestions()
+        bubbles.removeAll { bubble in
+            if case .suggestion = bubble { return true } else { return false }
+        }
+        bubbles.append(contentsOf: suggestions.map(ChatBubble.suggestion))
+    }
+
+    private func fetchWishes() async -> [Wish] {
+        (try? wishService.fetchWishes().sorted { $0.createdAt < $1.createdAt }) ?? []
+    }
+
+    private func fetchSuggestions() async -> [WishSuggestion] {
+        guard let wishes = try? await suggestionService.suggestTasks(for: .init(text: "")) else { return [] }
+        return wishes.map { WishSuggestion(title: $0.title, notes: $0.notes) }
+    }
+}

--- a/Wishle/UI/MainChat/SuggestionBubble.swift
+++ b/Wishle/UI/MainChat/SuggestionBubble.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Bubble view presenting an AI-generated ``WishSuggestion``.
+struct SuggestionBubble: View {
+    let suggestion: WishSuggestion
+    let onAdd: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(suggestion.title)
+                    .font(.body)
+                if let notes = suggestion.notes {
+                    Text(notes)
+                        .font(.caption)
+                }
+            }
+            Spacer()
+            Button("Add", action: onAdd)
+                .buttonStyle(.borderedProminent)
+                .tint(.white)
+                .foregroundStyle(Color("WishlePrimary"))
+                .accessibilityLabel("Add suggestion")
+        }
+        .padding(12)
+        .foregroundStyle(.white)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color("WishlePrimary"))
+        )
+    }
+}
+
+#Preview {
+    SuggestionBubble(suggestion: .init(title: "Try something new")) {}
+        .padding()
+}

--- a/Wishle/UI/MainChat/WishBubble.swift
+++ b/Wishle/UI/MainChat/WishBubble.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Bubble view presenting a persisted ``Wish``.
+struct WishBubble: View {
+    let wish: Wish
+    let onComplete: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(wish.title)
+                    .font(.body)
+                if let dueDate = wish.dueDate {
+                    Text(dueDate, style: .date)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color.secondary.opacity(0.2)))
+                }
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.primary.opacity(0.05)))
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .none, action: onComplete) {
+                Label("Complete", systemImage: "checkmark")
+            }
+            .tint(.green)
+            .accessibilityLabel("Complete wish")
+        }
+    }
+}
+
+#Preview {
+    WishBubble(wish: .init(title: "Sample Wish")) {}
+        .padding()
+}

--- a/Wishle/WishleApp.swift
+++ b/Wishle/WishleApp.swift
@@ -17,7 +17,8 @@ struct WishleApp: App {
 
     var sharedModelContainer: ModelContainer {
         let schema = Schema([
-            Item.self
+            Wish.self,
+            Tag.self
         ])
         let configuration: ModelConfiguration
         if subscriptionManager.isSubscribed {
@@ -35,7 +36,7 @@ struct WishleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainChatView()
                 .sheet(isPresented: $isPaywallPresented) {
                     PaywallView()
                 }

--- a/WishleTests/MainChatViewModelTests.swift
+++ b/WishleTests/MainChatViewModelTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import Wishle
+
+struct MainChatViewModelTests {
+    @Test
+    func testLoadSuccess() async {
+        let wish = Wish(title: "A")
+        let wishService = MockWishService(wishes: [wish])
+        let suggestion = Wish(title: "B")
+        let suggestionService = MockSuggestionService(result: .success([suggestion]))
+        let viewModel = MainChatViewModel(wishService: wishService, suggestionService: suggestionService)
+        await viewModel.load()
+        #expect(viewModel.bubbles.count == 2)
+    }
+
+    @Test
+    func testLoadFailure() async {
+        let wishService = MockWishService(error: TestError())
+        let suggestionService = MockSuggestionService(result: .failure(TestError()))
+        let viewModel = MainChatViewModel(wishService: wishService, suggestionService: suggestionService)
+        await viewModel.load()
+        #expect(viewModel.bubbles.isEmpty)
+    }
+}
+
+private struct TestError: Error {}
+
+private final class MockWishService: WishServiceProtocol {
+    var result: Result<[Wish], Error>
+
+    init(wishes: [Wish]) { result = .success(wishes) }
+    init(error: Error) { result = .failure(error) }
+
+    func fetchWishes() throws -> [Wish] { try result.get() }
+    func addWish(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish { .init(title: title) }
+    func wish(id: UUID) -> Wish? { nil }
+    func updateWish(_ wish: Wish) throws {}
+    func deleteWish(_ wish: Wish) throws {}
+    func nextUpWish() -> Wish? { nil }
+    var context: ModelContext { fatalError() }
+}
+
+private struct MockSuggestionService: AISuggestionServiceProtocol {
+    var result: Result<[Wish], Error>
+    func suggestTasks(for context: SuggestionContext) async throws -> [Wish] {
+        try result.get()
+    }
+}


### PR DESCRIPTION
## Summary
- add chat-based MainChatView with InputBar and bubble components
- expose new WishService and AISuggestionService protocol
- switch app root to MainChatView and update model schema
- document the flow in Docs/UI/main-chat-flow.md
- cover MainChatViewModel with unit tests

## Testing
- `swiftlint --fix --format --strict` *(fails: Loading libsourcekitdInProc.so failed)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5f4e3808320a2eae2c31cdddc52