### PR TITLE
feat(domain): introduce Wish AppEntity, SwiftData model, and CRUD AppIntents

### DIFF
--- a/Intents/Wish/AddWishIntent.swift
+++ b/Intents/Wish/AddWishIntent.swift
@@ -1,0 +1,37 @@
+import AppIntents
+import SwiftData
+
+@AppIntent
+struct AddWishIntent {
+    static var title: LocalizedStringResource = "Add Wish"
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Parameter(title: "Title")
+    var title: String
+
+    @Parameter(title: "Notes")
+    var notes: String?
+
+    @Parameter(title: "Priority", default: 0)
+    var priority: Int
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Add \(\.$title)") {
+            \.$notes
+            \.$priority
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .result()
+        }
+        let wish = Wish.make(title: title,
+                             notes: notes,
+                             priority: priority)
+        WishModel.create(from: wish, context: modelContext)
+        try modelContext.save()
+        return .result(value: wish)
+    }
+}

--- a/Intents/Wish/DeleteWishIntent.swift
+++ b/Intents/Wish/DeleteWishIntent.swift
@@ -1,0 +1,26 @@
+import AppIntents
+import SwiftData
+
+@AppIntent
+struct DeleteWishIntent {
+    static var title: LocalizedStringResource = "Delete Wish"
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Parameter(title: "ID")
+    var id: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Delete wish \(\.$id)")
+    }
+
+    func perform() async throws -> some IntentResult {
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
+        guard let model = try modelContext.fetch(descriptor).first else {
+            return .result()
+        }
+        modelContext.delete(model)
+        try modelContext.save()
+        return .result()
+    }
+}

--- a/Intents/Wish/UpdateWishIntent.swift
+++ b/Intents/Wish/UpdateWishIntent.swift
@@ -1,0 +1,46 @@
+import AppIntents
+import SwiftData
+
+@AppIntent
+struct UpdateWishIntent {
+    static var title: LocalizedStringResource = "Update Wish"
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Parameter(title: "ID")
+    var id: String
+
+    @Parameter(title: "Title")
+    var title: String?
+
+    @Parameter(title: "Notes")
+    var notes: String?
+
+    @Parameter(title: "Priority")
+    var priority: Int?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Update wish \(\.$id)") {
+            \.$title
+            \.$notes
+            \.$priority
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
+        guard let model = try modelContext.fetch(descriptor).first else {
+            return .result()
+        }
+        if let title {
+            guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .result()
+            }
+            model.title = title
+        }
+        if let notes { model.notes = notes }
+        if let priority { model.priority = priority }
+        try modelContext.save()
+        return .result(value: model.asWish())
+    }
+}

--- a/Sources/CoreData/WishModel.swift
+++ b/Sources/CoreData/WishModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+import SwiftData
+
+@Model
+final class WishModel {
+    @Attribute(.unique) var id = UUID().uuidString
+    private(set) var title: String
+    private(set) var notes: String?
+    private(set) var createdAt: Date
+    private(set) var priority: Int
+
+    init(title: String,
+         notes: String? = nil,
+         createdAt: Date = .init(),
+         priority: Int = 0) {
+        self.title = title
+        self.notes = notes
+        self.createdAt = createdAt
+        self.priority = priority
+    }
+
+    static func create(from wish: Wish,
+                       context: ModelContext) -> WishModel {
+        let model = WishModel(title: wish.title,
+                              notes: wish.notes,
+                              createdAt: wish.createdAt,
+                              priority: wish.priority)
+        context.insert(model)
+        return model
+    }
+
+    func asWish() -> Wish { .init(id: id,
+                                  title: title,
+                                  notes: notes,
+                                  createdAt: createdAt,
+                                  priority: priority) }
+}

--- a/Sources/Domain/Wish.swift
+++ b/Sources/Domain/Wish.swift
@@ -1,0 +1,25 @@
+import AppIntents
+import Foundation
+
+public struct Wish: AppEntity, Identifiable, Hashable {
+    public let id: String
+    public private(set) var title: String
+    public private(set) var notes: String?
+    public private(set) var createdAt: Date
+    public private(set) var priority: Int
+
+    public var displayRepresentation: DisplayRepresentation {
+        .init(title: "\(title)")
+    }
+
+    static func make(title: String,
+                     notes: String? = nil,
+                     priority: Int = 0,
+                     now: @autoclosure () -> Date = .init()) -> Wish {
+        .init(id: UUID().uuidString,
+              title: title,
+              notes: notes,
+              createdAt: now(),
+              priority: priority)
+    }
+}

--- a/Tests/AddWishIntentTests.swift
+++ b/Tests/AddWishIntentTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import SwiftData
+@testable import Wishle
+
+struct AddWishIntentTests {
+    private func makeContext() throws -> ModelContext {
+        let schema = Schema([WishModel.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return container.mainContext
+    }
+
+    @MainActor
+    @Test func testAddWish() async throws {
+        let context = try makeContext()
+        var intent = AddWishIntent()
+        intent.title = "Hello"
+        intent.notes = "note"
+        intent.priority = 1
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let wishes = try context.fetch(FetchDescriptor<WishModel>())
+        #expect(wishes.count == 1)
+        #expect(wishes.first?.title == "Hello")
+    }
+
+    @MainActor
+    @Test func testAddWishEmptyTitle() async throws {
+        let context = try makeContext()
+        var intent = AddWishIntent()
+        intent.title = ""
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let wishes = try context.fetch(FetchDescriptor<WishModel>())
+        #expect(wishes.isEmpty)
+    }
+}

--- a/Tests/DeleteWishIntentTests.swift
+++ b/Tests/DeleteWishIntentTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import SwiftData
+@testable import Wishle
+
+struct DeleteWishIntentTests {
+    private func makeContext() throws -> ModelContext {
+        let schema = Schema([WishModel.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return container.mainContext
+    }
+
+    @MainActor
+    @Test func testDeleteWish() async throws {
+        let context = try makeContext()
+        let model = WishModel.create(from: Wish.make(title: "temp"), context: context)
+        try context.save()
+        var intent = DeleteWishIntent()
+        intent.id = model.id
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let wishes = try context.fetch(FetchDescriptor<WishModel>())
+        #expect(wishes.isEmpty)
+    }
+
+    @MainActor
+    @Test func testDeleteInvalidId() async throws {
+        let context = try makeContext()
+        var intent = DeleteWishIntent()
+        intent.id = "invalid"
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let wishes = try context.fetch(FetchDescriptor<WishModel>())
+        #expect(wishes.isEmpty)
+    }
+}

--- a/Tests/UpdateWishIntentTests.swift
+++ b/Tests/UpdateWishIntentTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import SwiftData
+@testable import Wishle
+
+struct UpdateWishIntentTests {
+    private func makeContext() throws -> ModelContext {
+        let schema = Schema([WishModel.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return container.mainContext
+    }
+
+    @MainActor
+    @Test func testUpdateWish() async throws {
+        let context = try makeContext()
+        let wish = Wish.make(title: "Old")
+        let model = WishModel.create(from: wish, context: context)
+        try context.save()
+        var intent = UpdateWishIntent()
+        intent.id = model.id
+        intent.title = "New"
+        intent.priority = 2
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let updated = try context.fetch(FetchDescriptor<WishModel>()).first!
+        #expect(updated.title == "New")
+        #expect(updated.priority == 2)
+    }
+
+    @MainActor
+    @Test func testUpdateInvalidId() async throws {
+        let context = try makeContext()
+        var intent = UpdateWishIntent()
+        intent.id = "invalid"
+        intent.title = "New"
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let wishes = try context.fetch(FetchDescriptor<WishModel>())
+        #expect(wishes.isEmpty)
+    }
+
+    @MainActor
+    @Test func testUpdateEmptyTitle() async throws {
+        let context = try makeContext()
+        let model = WishModel.create(from: Wish.make(title: "Old"), context: context)
+        try context.save()
+        var intent = UpdateWishIntent()
+        intent.id = model.id
+        intent.title = ""
+        intent.modelContext = context
+        _ = try await intent.perform()
+        let loaded = try context.fetch(FetchDescriptor<WishModel>()).first!
+        #expect(loaded.title == "Old")
+    }
+}


### PR DESCRIPTION
## Summary
- define `Wish` AppEntity
- add SwiftData `WishModel`
- add AppIntent commands for Wish CRUD
- cover Add, Update and Delete intents with tests

## Testing
- `swiftlint --strict` *(fails: command not found)*
- `swift test --package-path SubscriptionManager` *(fails: no such module 'StoreKit')*

------
https://chatgpt.com/codex/tasks/task_e_6851ab00f5e08320b70da11f6c382ab9