### PR TITLE
Add Input/Output Intent performer pattern

### DIFF
--- a/Wishle/Sources/Shared/Intent/ImportRemindersIntent.swift
+++ b/Wishle/Sources/Shared/Intent/ImportRemindersIntent.swift
@@ -6,14 +6,23 @@
 //
 
 import AppIntents
+import SwiftUtilities
 
-struct ImportRemindersIntent: AppIntent {
+struct ImportRemindersIntent: AppIntent, IntentPerformer {
     static var title: LocalizedStringResource = "Import Reminders"
 
     var importer: RemindersImporter = .init()
 
+    typealias Input = RemindersImporter
+    typealias Output = Void
+
+    static func perform(_ input: RemindersImporter) async throws {
+        try await input.import()
+    }
+
+    @MainActor
     func perform() async throws -> some IntentResult {
-        try await importer.import()
+        try await Self.perform(importer)
         return .result()
     }
 }

--- a/Wishle/Sources/Shared/Model/RemindersImporter.swift
+++ b/Wishle/Sources/Shared/Model/RemindersImporter.swift
@@ -33,18 +33,24 @@ struct RemindersImporter {
                 if let existing = try findTask(for: reminder, tag: tag) {
                     if let lastModified = reminder.lastModifiedDate,
                        lastModified > existing.updatedAt {
-                        existing.title = title
-                        existing.notes = notes
-                        existing.dueDate = dueDate
-                        existing.isCompleted = reminder.isCompleted
-                        existing.priority = priority
-                        try await service.updateTask(existing)
+                        try await UpdateTaskIntent.perform((
+                            context: service.context,
+                            id: existing.id.uuidString,
+                            title: title,
+                            notes: notes,
+                            dueDate: dueDate,
+                            isCompleted: reminder.isCompleted,
+                            priority: priority
+                        ))
                     }
                 } else {
-                    let task = try await service.addTask(title: title,
-                                                         notes: notes,
-                                                         dueDate: dueDate,
-                                                         priority: priority)
+                    let task = try await AddTaskIntent.perform((
+                        context: service.context,
+                        title: title,
+                        notes: notes,
+                        dueDate: dueDate,
+                        priority: priority
+                    ))
                     task.isCompleted = reminder.isCompleted
                     task.tags.append(tag)
                     try await service.updateTask(task)

--- a/Wishle/Sources/Wish/Intent/DeleteTaskIntent.swift
+++ b/Wishle/Sources/Wish/Intent/DeleteTaskIntent.swift
@@ -6,26 +6,41 @@
 //
 
 import AppIntents
+import SwiftData
+import SwiftUtilities
 
-struct DeleteTaskIntent: AppIntent {
+struct DeleteTaskIntent: AppIntent, IntentPerformer {
     static var title: LocalizedStringResource = "Delete Task"
 
     /// Service injected from the application context.
     var service: TaskServiceProtocol = TaskService.shared
+    @Dependency private var modelContainer: ModelContainer
 
     @Parameter(title: "ID")
-    var id: String
+    private var id: String
 
     static var parameterSummary: some ParameterSummary {
         Summary("Delete task \(\.$id)")
     }
 
-    func perform() async throws -> some IntentResult {
-        guard let uuid = UUID(uuidString: id),
-              let task = service.task(id: uuid) else {
-            return .result()
+    typealias Input = (context: ModelContext, id: String)
+    typealias Output = Void
+
+    static func perform(_ input: Input) async throws {
+        let (context, id) = input
+        let service = TaskService(modelContext: context)
+        guard let uuid = UUID(uuidString: id), let task = service.task(id: uuid) else {
+            return
         }
         try await service.deleteTask(task)
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        try await Self.perform((
+            context: modelContainer.mainContext,
+            id: id
+        ))
         return .result()
     }
 }


### PR DESCRIPTION
## Summary
- remove local `IntentPerformer` and import it from SwiftUtilities
- add `modelContainer` dependency in intent `perform` methods
- call static `perform` with `modelContainer.mainContext`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: Loading libsourcekitdInProc.so failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852427831f08320b5816aa8f08c10ba