### PR TITLE
Add AppEntity conformance for Wish model

### DIFF
--- a/Wishle/Sources/Wish/Model/Wish.swift
+++ b/Wishle/Sources/Wish/Model/Wish.swift
@@ -7,10 +7,27 @@
 
 import Foundation
 import SwiftData
+import AppIntents
 
 /// A wish item within Wishle.
 @Model
-final class Wish: Identifiable, Hashable {
+final class Wish: Identifiable, Hashable, AppEntity {
+    static let defaultQuery = WishEntityQuery()
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        .init(
+            name: .init("Wish", table: "AppIntents"),
+            numericFormat: LocalizedStringResource("\(placeholder: .int) Wishes", table: "AppIntents")
+        )
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        .init(
+            title: .init(title, table: "AppIntents"),
+            subtitle: notes.map { .init($0, table: "AppIntents") },
+            image: .init(systemName: isCompleted ? "checkmark.circle.fill" : "circle")
+        )
+    }
     /// Unique identifier for the wish.
     @Attribute(.unique) var id: UUID
     /// The user-facing title.

--- a/Wishle/Sources/Wish/Model/WishEntityQuery.swift
+++ b/Wishle/Sources/Wish/Model/WishEntityQuery.swift
@@ -1,0 +1,33 @@
+//
+//  WishEntityQuery.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import AppIntents
+import SwiftData
+
+struct WishEntityQuery: EntityStringQuery {
+    @Dependency private var modelContainer: ModelContainer
+
+    @MainActor
+    func entities(for identifiers: [Wish.ID]) throws -> [Wish] {
+        try identifiers.compactMap { identifier in
+            let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.id == identifier })
+            return try modelContainer.mainContext.fetch(descriptor).first
+        }
+    }
+
+    @MainActor
+    func entities(matching string: String) throws -> [Wish] {
+        try modelContainer.mainContext.fetch(
+            FetchDescriptor<Wish>(predicate: #Predicate { $0.title.localizedStandardContains(string) })
+        )
+    }
+
+    @MainActor
+    func suggestedEntities() throws -> [Wish] {
+        try modelContainer.mainContext.fetch(FetchDescriptor<Wish>())
+    }
+}


### PR DESCRIPTION
## Summary
- make `Wish` conform to `AppEntity`
- add display representation and default query
- implement `WishEntityQuery` for App Intent integration

## Testing
- `swiftlint` *(fails: Loading libsourcekitdInProc.so failed)*

------
https://chatgpt.com/codex/tasks/task_e_68526b87c01883208e439ba07be25bb2