### PR TITLE
Add WishModel for SwiftData

### DIFF
--- a/Wishle/Sources/Shared/Model/RemindersExporter.swift
+++ b/Wishle/Sources/Shared/Model/RemindersExporter.swift
@@ -21,8 +21,9 @@ struct RemindersExporter {
 
     func export() async throws {
         try await eventStore.requestFullAccessToReminders()
-        let tasks = try service.context.fetch(FetchDescriptor<Wish>())
-        for task in tasks {
+        let models = try service.context.fetch(FetchDescriptor<WishModel>())
+        for model in models {
+            let task = model.wish
             for tag in task.tags {
                 let calendar = try fetchOrCreateCalendar(name: tag.name)
                 if let reminder = try await findReminder(for: task, in: calendar) {

--- a/Wishle/Sources/Shared/Model/RemindersImporter.swift
+++ b/Wishle/Sources/Shared/Model/RemindersImporter.swift
@@ -73,8 +73,8 @@ struct RemindersImporter {
 
     private func findTask(for reminder: EKReminder, tag: Tag) throws -> Wish? {
         guard let title = reminder.title else { return nil }
-        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.title == title })
-        let tasks = try service.context.fetch(descriptor)
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.title == title })
+        let tasks = try service.context.fetch(descriptor).map(\.wish)
         let dueDate = reminder.dueDateComponents?.date
         return tasks.first { $0.dueDate == dueDate && $0.tags.contains(tag) }
     }

--- a/Wishle/Sources/Tag/Model/Tag.swift
+++ b/Wishle/Sources/Tag/Model/Tag.swift
@@ -24,11 +24,11 @@ final class Tag: Identifiable, Hashable {
     }
 
     /// Wishes that include this tag.
-    @Relationship(inverse: \Wish.tags) var wishes: [Wish] = []
+    @Relationship(inverse: \WishModel.tags) var wishes: [WishModel] = []
 
     init(id: UUID = .init(),
          name: String,
-         wishes: [Wish] = []) {
+         wishes: [WishModel] = []) {
         self.id = id
         self.name = name.lowercased()
         self.wishes = wishes

--- a/Wishle/Sources/Wish/Model/TaskService.swift
+++ b/Wishle/Sources/Wish/Model/TaskService.swift
@@ -37,7 +37,7 @@ final class TaskService: TaskServiceProtocol {
     static var shared: TaskService = {
         do {
             let schema = Schema([
-                Wish.self,
+                WishModel.self,
                 Tag.self
             ])
             let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
@@ -60,33 +60,43 @@ final class TaskService: TaskServiceProtocol {
     }
 
     func task(id: UUID) -> Wish? {
-        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.id == id })
-        return try? modelContext.fetch(descriptor).first
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
+        return try? modelContext.fetch(descriptor).first?.wish
     }
 
     func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish {
-        let task = Wish(title: title, notes: notes, dueDate: dueDate, priority: priority)
-        modelContext.insert(task)
+        let model = WishModel.create(
+            context: modelContext,
+            title: title,
+            notes: notes,
+            dueDate: dueDate,
+            priority: priority
+        )
         try modelContext.save()
-        return task
+        return model.wish
     }
 
     func updateTask(_ task: Wish) throws {
-        task.updatedAt = .now
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == task.id })
+        guard let model = try modelContext.fetch(descriptor).first else { return }
+        model.update(from: task)
         try modelContext.save()
     }
 
     func deleteTask(_ task: Wish) throws {
-        modelContext.delete(task)
-        try modelContext.save()
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == task.id })
+        if let model = try modelContext.fetch(descriptor).first {
+            modelContext.delete(model)
+            try modelContext.save()
+        }
     }
 
     func nextUpTask() -> Wish? {
-        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { !$0.isCompleted })
-        guard let tasks = try? modelContext.fetch(descriptor) else {
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { !$0.isCompleted })
+        guard let models = try? modelContext.fetch(descriptor) else {
             return nil
         }
-        return tasks.sorted { lhs, rhs in
+        return models.sorted { lhs, rhs in
             switch (lhs.dueDate, rhs.dueDate) {
             case let (lhsDate?, rhsDate?):
                 if lhsDate != rhsDate {
@@ -100,6 +110,6 @@ final class TaskService: TaskServiceProtocol {
             case (_, nil):
                 return true
             }
-        }.first
+        }.first?.wish
     }
 }

--- a/Wishle/Sources/Wish/Model/Wish.swift
+++ b/Wishle/Sources/Wish/Model/Wish.swift
@@ -6,11 +6,9 @@
 //
 
 import Foundation
-import SwiftData
 import AppIntents
 
 /// A wish item within Wishle.
-@Model
 final class Wish: Identifiable, Hashable, AppEntity {
     static let defaultQuery = WishEntityQuery()
 
@@ -29,7 +27,7 @@ final class Wish: Identifiable, Hashable, AppEntity {
         )
     }
     /// Unique identifier for the wish.
-    @Attribute(.unique) var id: UUID
+    var id: UUID
     /// The user-facing title.
     var title: String
     /// Optional notes about the wish.
@@ -45,8 +43,8 @@ final class Wish: Identifiable, Hashable, AppEntity {
     /// Last update timestamp.
     var updatedAt: Date
 
-    /// Tags associated with the wish. Removing the wish deletes its tags.
-    @Relationship(deleteRule: .cascade) var tags: [Tag] = []
+    /// Tags associated with the wish.
+    var tags: [Tag] = []
 
     /// Returns true when the due date has passed and the wish is not completed.
     var isOverdue: Bool {
@@ -72,5 +70,20 @@ final class Wish: Identifiable, Hashable, AppEntity {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.tags = tags
+    }
+}
+
+extension Wish {
+    /// Creates an instance from the SwiftData model.
+    convenience init(_ model: WishModel) {
+        self.init(id: model.id,
+                  title: model.title,
+                  notes: model.notes,
+                  dueDate: model.dueDate,
+                  isCompleted: model.isCompleted,
+                  priority: model.priority,
+                  createdAt: model.createdAt,
+                  updatedAt: model.updatedAt,
+                  tags: model.tags)
     }
 }

--- a/Wishle/Sources/Wish/Model/WishEntityQuery.swift
+++ b/Wishle/Sources/Wish/Model/WishEntityQuery.swift
@@ -14,20 +14,20 @@ struct WishEntityQuery: EntityStringQuery {
     @MainActor
     func entities(for identifiers: [Wish.ID]) throws -> [Wish] {
         try identifiers.compactMap { identifier in
-            let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.id == identifier })
-            return try modelContainer.mainContext.fetch(descriptor).first
+            let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == identifier })
+            return try modelContainer.mainContext.fetch(descriptor).first.map(Wish.init)
         }
     }
 
     @MainActor
     func entities(matching string: String) throws -> [Wish] {
         try modelContainer.mainContext.fetch(
-            FetchDescriptor<Wish>(predicate: #Predicate { $0.title.localizedStandardContains(string) })
-        )
+            FetchDescriptor<WishModel>(predicate: #Predicate { $0.title.localizedStandardContains(string) })
+        ).map(Wish.init)
     }
 
     @MainActor
     func suggestedEntities() throws -> [Wish] {
-        try modelContainer.mainContext.fetch(FetchDescriptor<Wish>())
+        try modelContainer.mainContext.fetch(FetchDescriptor<WishModel>()).map(Wish.init)
     }
 }

--- a/Wishle/Sources/Wish/Model/WishModel.swift
+++ b/Wishle/Sources/Wish/Model/WishModel.swift
@@ -1,0 +1,62 @@
+//
+//  WishModel.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class WishModel {
+    @Attribute(.unique) private(set) var id: UUID = .init()
+    private(set) var title = String()
+    private(set) var notes: String?
+    private(set) var dueDate: Date?
+    private(set) var isCompleted = false
+    private(set) var priority = 0
+    private(set) var createdAt = Date.now
+    private(set) var updatedAt = Date.now
+    @Relationship(deleteRule: .cascade, inverse: \Tag.wishes) private(set) var tags: [Tag] = []
+
+    private init() {}
+
+    static func create(context: ModelContext,
+                       title: String,
+                       notes: String?,
+                       dueDate: Date?,
+                       priority: Int) -> WishModel {
+        let model = WishModel()
+        context.insert(model)
+        model.title = title
+        model.notes = notes
+        model.dueDate = dueDate
+        model.priority = priority
+        return model
+    }
+
+    func update(from wish: Wish) {
+        title = wish.title
+        notes = wish.notes
+        dueDate = wish.dueDate
+        isCompleted = wish.isCompleted
+        priority = wish.priority
+        updatedAt = wish.updatedAt
+        tags = wish.tags
+    }
+}
+
+extension WishModel {
+    var wish: Wish {
+        .init(id: id,
+              title: title,
+              notes: notes,
+              dueDate: dueDate,
+              isCompleted: isCompleted,
+              priority: priority,
+              createdAt: createdAt,
+              updatedAt: updatedAt,
+              tags: tags)
+    }
+}


### PR DESCRIPTION
## Summary
- create `WishModel` for SwiftData persistence
- convert `Wish` to a plain object and map to `WishModel`
- update related services, queries, and importer/exporter logic
- adjust tag relationship for the new model

## Testing
- `pre-commit` *(fails: error fetching SwiftLint)*

------
https://chatgpt.com/codex/tasks/task_e_68527390c228832092b0089dc2840c7e