### PR TITLE
Add WishModel for SwiftData

### DIFF
--- a/Wishle/Sources/Shared/Model/RemindersExporter.swift
+++ b/Wishle/Sources/Shared/Model/RemindersExporter.swift
@@ -21,8 +21,9 @@ struct RemindersExporter {
 
     func export() async throws {
         try await eventStore.requestFullAccessToReminders()
-        let tasks = try service.context.fetch(FetchDescriptor<Wish>())
-        for task in tasks {
+        let models = try service.context.fetch(FetchDescriptor<WishModel>())
+        for model in models {
+            let task = model.wish
             for tag in task.tags {
                 let calendar = try fetchOrCreateCalendar(name: tag.name)
                 if let reminder = try await findReminder(for: task, in: calendar) {

--- a/Wishle/Sources/Shared/Model/RemindersImporter.swift
+++ b/Wishle/Sources/Shared/Model/RemindersImporter.swift
@@ -44,7 +44,7 @@ struct RemindersImporter {
                         ))
                     }
                 } else {
-                    let task = try await AddTaskIntent.perform((
+                    var task = try await AddTaskIntent.perform((
                         context: service.context,
                         title: title,
                         notes: notes,
@@ -73,10 +73,10 @@ struct RemindersImporter {
 
     private func findTask(for reminder: EKReminder, tag: Tag) throws -> Wish? {
         guard let title = reminder.title else { return nil }
-        let descriptor = FetchDescriptor<Wish>(predicate: #Predicate { $0.title == title })
-        let tasks = try service.context.fetch(descriptor)
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.title == title })
+        let models = try service.context.fetch(descriptor)
         let dueDate = reminder.dueDateComponents?.date
-        return tasks.first { $0.dueDate == dueDate && $0.tags.contains(tag) }
+        return models.map { $0.wish }.first { $0.dueDate == dueDate && $0.tags.contains(tag) }
     }
 
     private func requestFullAccessToRemindersAsync() async throws {

--- a/Wishle/Sources/Tag/Model/Tag.swift
+++ b/Wishle/Sources/Tag/Model/Tag.swift
@@ -24,11 +24,11 @@ final class Tag: Identifiable, Hashable {
     }
 
     /// Wishes that include this tag.
-    @Relationship(inverse: \Wish.tags) var wishes: [Wish] = []
+    @Relationship(inverse: \WishModel.tags) var wishes: [WishModel] = []
 
     init(id: UUID = .init(),
          name: String,
-         wishes: [Wish] = []) {
+         wishes: [WishModel] = []) {
         self.id = id
         self.name = name.lowercased()
         self.wishes = wishes

--- a/Wishle/Sources/Wish/Intent/UpdateTaskIntent.swift
+++ b/Wishle/Sources/Wish/Intent/UpdateTaskIntent.swift
@@ -50,7 +50,7 @@ struct UpdateTaskIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) async throws {
         let (context, id, title, notes, dueDate, isCompleted, priority) = input
         let service = TaskService(modelContext: context)
-        guard let uuid = UUID(uuidString: id), let task = service.task(id: uuid) else {
+        guard let uuid = UUID(uuidString: id), var task = service.task(id: uuid) else {
             return
         }
         if let title { task.title = title }

--- a/Wishle/Sources/Wish/Model/WishModel.swift
+++ b/Wishle/Sources/Wish/Model/WishModel.swift
@@ -1,16 +1,18 @@
 //
-//  Wish.swift
+//  WishModel.swift
 //  Wishle
 //
-//  Created by Hiromu Nakano on 2025/06/17.
+//  Created by Codex on 2025/06/17.
 //
 
 import Foundation
+import SwiftData
 
-/// In-memory representation of a wish item.
-struct Wish: Identifiable, Hashable {
+/// SwiftData model object for persisting wishes.
+@Model
+final class WishModel: Identifiable, Hashable {
     /// Unique identifier for the wish.
-    var id: UUID
+    @Attribute(.unique) var id: UUID
     /// The user-facing title.
     var title: String
     /// Optional notes about the wish.
@@ -26,8 +28,8 @@ struct Wish: Identifiable, Hashable {
     /// Last update timestamp.
     var updatedAt: Date
 
-    /// Tags associated with the wish.
-    var tags: [Tag] = []
+    /// Tags associated with the wish. Removing the wish deletes its tags.
+    @Relationship(deleteRule: .cascade) var tags: [Tag] = []
 
     /// Returns true when the due date has passed and the wish is not completed.
     var isOverdue: Bool {
@@ -54,19 +56,36 @@ struct Wish: Identifiable, Hashable {
         self.updatedAt = updatedAt
         self.tags = tags
     }
+}
 
-    /// Creates a ``Wish`` from a ``WishModel``.
-    init(_ model: WishModel) {
+extension WishModel {
+    /// Creates a ``WishModel`` from a ``Wish``.
+    convenience init(_ wish: Wish) {
         self.init(
-            id: model.id,
-            title: model.title,
-            notes: model.notes,
-            dueDate: model.dueDate,
-            isCompleted: model.isCompleted,
-            priority: model.priority,
-            createdAt: model.createdAt,
-            updatedAt: model.updatedAt,
-            tags: model.tags
+            id: wish.id,
+            title: wish.title,
+            notes: wish.notes,
+            dueDate: wish.dueDate,
+            isCompleted: wish.isCompleted,
+            priority: wish.priority,
+            createdAt: wish.createdAt,
+            updatedAt: wish.updatedAt,
+            tags: wish.tags
+        )
+    }
+
+    /// Returns a plain ``Wish`` representation.
+    var wish: Wish {
+        .init(
+            id: id,
+            title: title,
+            notes: notes,
+            dueDate: dueDate,
+            isCompleted: isCompleted,
+            priority: priority,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            tags: tags
         )
     }
 }


### PR DESCRIPTION
## Summary
- introduce `WishModel` for SwiftData persistence
- turn `Wish` into a lightweight struct
- convert `TaskService` and importer/exporter utilities to use `WishModel`
- update intents for struct-based wishes

## Testing
- `swiftlint`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685286ea9b9c8320be5d594d537ebd2a