### PR TITLE
Add TagModel and switch IDs to String

### DIFF
--- a/Wishle/Sources/Shared/Model/RemindersImporter.swift
+++ b/Wishle/Sources/Shared/Model/RemindersImporter.swift
@@ -35,7 +35,7 @@ struct RemindersImporter {
                        lastModified > existing.updatedAt {
                         try await UpdateTaskIntent.perform((
                             context: service.context,
-                            id: existing.id.uuidString,
+                            id: existing.id,
                             title: title,
                             notes: notes,
                             dueDate: dueDate,
@@ -61,14 +61,14 @@ struct RemindersImporter {
 
     private func fetchOrCreateTag(name: String) throws -> Tag {
         let lowercasedName = name.lowercased()
-        let descriptor = FetchDescriptor<Tag>(predicate: #Predicate { $0.name == lowercasedName })
-        if let tag = try service.context.fetch(descriptor).first {
-            return tag
+        let descriptor = FetchDescriptor<TagModel>(predicate: #Predicate { $0.name == lowercasedName })
+        if let model = try service.context.fetch(descriptor).first {
+            return model.tag
         }
-        let tag = Tag(name: name)
-        service.context.insert(tag)
+        let model = TagModel(name: name)
+        service.context.insert(model)
         try service.context.save()
-        return tag
+        return model.tag
     }
 
     private func findTask(for reminder: EKReminder, tag: Tag) throws -> Wish? {

--- a/Wishle/Sources/Tag/Model/Tag.swift
+++ b/Wishle/Sources/Tag/Model/Tag.swift
@@ -6,15 +6,13 @@
 //
 
 import Foundation
-import SwiftData
 
-/// A tag used to categorize wishes.
-@Model
-final class Tag: Identifiable, Hashable {
+/// In-memory representation of a tag used to categorize wishes.
+struct Tag: Identifiable, Hashable {
     /// Unique identifier for the tag.
-    @Attribute(.unique) var id: UUID
+    var id: String
     /// Lowercased unique name of the tag.
-    @Attribute(.unique) var name: String {
+    var name: String {
         didSet {
             let lowercasedName = name.lowercased()
             if name != lowercasedName {
@@ -23,15 +21,15 @@ final class Tag: Identifiable, Hashable {
         }
     }
 
-    /// Wishes that include this tag.
-    @Relationship(inverse: \WishModel.tags) var wishes: [WishModel] = []
-
-    init(id: UUID = .init(),
-         name: String,
-         wishes: [WishModel] = []) {
+    init(id: String = UUID().uuidString,
+         name: String) {
         self.id = id
         self.name = name.lowercased()
-        self.wishes = wishes
+    }
+
+    /// Creates a ``Tag`` from a ``TagModel``.
+    init(_ model: TagModel) {
+        self.init(id: model.id, name: model.name)
     }
 
     /// Sample tags for preview usage.

--- a/Wishle/Sources/Tag/Model/TagModel.swift
+++ b/Wishle/Sources/Tag/Model/TagModel.swift
@@ -1,0 +1,48 @@
+//
+//  TagModel.swift
+//  Wishle
+//
+//  Created by Hiromu Nakano on 2025/06/17.
+//
+
+import Foundation
+import SwiftData
+
+/// SwiftData model object for persisting tags.
+@Model
+final class TagModel: Identifiable, Hashable {
+    /// Unique identifier for the tag.
+    @Attribute(.unique) var id: String
+    /// Lowercased unique name of the tag.
+    @Attribute(.unique) var name: String {
+        didSet {
+            let lowercasedName = name.lowercased()
+            if name != lowercasedName {
+                name = lowercasedName
+            }
+        }
+    }
+
+    /// Wishes that include this tag.
+    @Relationship(inverse: \WishModel.tags) var wishes: [WishModel] = []
+
+    init(id: String = UUID().uuidString,
+         name: String,
+         wishes: [WishModel] = []) {
+        self.id = id
+        self.name = name.lowercased()
+        self.wishes = wishes
+    }
+}
+
+extension TagModel {
+    /// Creates a ``TagModel`` from a ``Tag``.
+    convenience init(_ tag: Tag) {
+        self.init(id: tag.id, name: tag.name)
+    }
+
+    /// Returns a plain ``Tag`` representation.
+    var tag: Tag {
+        .init(id: id, name: name)
+    }
+}

--- a/Wishle/Sources/Wish/Intent/DeleteTaskIntent.swift
+++ b/Wishle/Sources/Wish/Intent/DeleteTaskIntent.swift
@@ -29,7 +29,7 @@ struct DeleteTaskIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) async throws {
         let (context, id) = input
         let service = TaskService(modelContext: context)
-        guard let uuid = UUID(uuidString: id), let task = service.task(id: uuid) else {
+        guard let task = service.task(id: id) else {
             return
         }
         try await service.deleteTask(task)

--- a/Wishle/Sources/Wish/Intent/UpdateTaskIntent.swift
+++ b/Wishle/Sources/Wish/Intent/UpdateTaskIntent.swift
@@ -50,7 +50,7 @@ struct UpdateTaskIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) async throws {
         let (context, id, title, notes, dueDate, isCompleted, priority) = input
         let service = TaskService(modelContext: context)
-        guard let uuid = UUID(uuidString: id), var task = service.task(id: uuid) else {
+        guard var task = service.task(id: id) else {
             return
         }
         if let title { task.title = title }

--- a/Wishle/Sources/Wish/Model/TaskService.swift
+++ b/Wishle/Sources/Wish/Model/TaskService.swift
@@ -15,7 +15,7 @@ protocol TaskServiceProtocol {
     func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Wish
 
     /// Finds a task for the given identifier.
-    func task(id: UUID) -> Wish?
+    func task(id: String) -> Wish?
 
     /// Persists updates to the provided task.
     func updateTask(_ task: Wish) async throws
@@ -38,7 +38,7 @@ final class TaskService: TaskServiceProtocol {
         do {
             let schema = Schema([
                 WishModel.self,
-                Tag.self
+                TagModel.self
             ])
             let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
             let container = try ModelContainer(for: schema, configurations: [configuration])
@@ -59,7 +59,8 @@ final class TaskService: TaskServiceProtocol {
         self.modelContext = modelContext
     }
 
-    func task(id: UUID) -> Wish? {
+    func task(id: String) -> Wish? {
+        let id = id
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
         guard let model = try? modelContext.fetch(descriptor).first else {
             return nil
@@ -92,7 +93,7 @@ final class TaskService: TaskServiceProtocol {
         model.isCompleted = task.isCompleted
         model.priority = task.priority
         model.updatedAt = .now
-        model.tags = task.tags
+        model.tags = task.tags.map(TagModel.init)
         try modelContext.save()
     }
 

--- a/Wishle/Sources/Wish/Model/Wish.swift
+++ b/Wishle/Sources/Wish/Model/Wish.swift
@@ -10,7 +10,7 @@ import Foundation
 /// In-memory representation of a wish item.
 struct Wish: Identifiable, Hashable {
     /// Unique identifier for the wish.
-    var id: UUID
+    var id: String
     /// The user-facing title.
     var title: String
     /// Optional notes about the wish.
@@ -35,7 +35,7 @@ struct Wish: Identifiable, Hashable {
         return dueDate < .now && !isCompleted
     }
 
-    init(id: UUID = .init(),
+    init(id: String = UUID().uuidString,
          title: String,
          notes: String? = nil,
          dueDate: Date? = nil,
@@ -66,7 +66,7 @@ struct Wish: Identifiable, Hashable {
             priority: model.priority,
             createdAt: model.createdAt,
             updatedAt: model.updatedAt,
-            tags: model.tags
+            tags: model.tags.map(\.tag)
         )
     }
 }

--- a/Wishle/Sources/Wish/Model/WishModel.swift
+++ b/Wishle/Sources/Wish/Model/WishModel.swift
@@ -12,7 +12,7 @@ import SwiftData
 @Model
 final class WishModel: Identifiable, Hashable {
     /// Unique identifier for the wish.
-    @Attribute(.unique) var id: UUID
+    @Attribute(.unique) var id: String
     /// The user-facing title.
     var title: String
     /// Optional notes about the wish.
@@ -29,7 +29,7 @@ final class WishModel: Identifiable, Hashable {
     var updatedAt: Date
 
     /// Tags associated with the wish. Removing the wish deletes its tags.
-    @Relationship(deleteRule: .cascade) var tags: [Tag] = []
+    @Relationship(deleteRule: .cascade) var tags: [TagModel] = []
 
     /// Returns true when the due date has passed and the wish is not completed.
     var isOverdue: Bool {
@@ -37,7 +37,7 @@ final class WishModel: Identifiable, Hashable {
         return dueDate < .now && !isCompleted
     }
 
-    init(id: UUID = .init(),
+    init(id: String = UUID().uuidString,
          title: String,
          notes: String? = nil,
          dueDate: Date? = nil,
@@ -45,7 +45,7 @@ final class WishModel: Identifiable, Hashable {
          priority: Int = 0,
          createdAt: Date = .now,
          updatedAt: Date = .now,
-         tags: [Tag] = []) {
+         tags: [TagModel] = []) {
         self.id = id
         self.title = title
         self.notes = notes
@@ -70,7 +70,7 @@ extension WishModel {
             priority: wish.priority,
             createdAt: wish.createdAt,
             updatedAt: wish.updatedAt,
-            tags: wish.tags
+            tags: wish.tags.map(TagModel.init)
         )
     }
 
@@ -85,7 +85,7 @@ extension WishModel {
             priority: priority,
             createdAt: createdAt,
             updatedAt: updatedAt,
-            tags: tags
+            tags: tags.map(\.tag)
         )
     }
 }


### PR DESCRIPTION
## Summary
- introduce `TagModel` for persistence
- store IDs as `String` across wish and tag models
- update task service, intents, and importer for new models

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a38171b48320a40dae3b2a16b662