### PR TITLE
Refactor Task references to Wish

### DIFF
--- a/Wishle/Sources/Shared/Models/AISuggestionService.swift
+++ b/Wishle/Sources/Shared/Models/AISuggestionService.swift
@@ -2,18 +2,18 @@ import Foundation
 import FoundationModels
 
 @Generable
-private struct TaskSuggestion: Decodable {
+private struct WishSuggestion: Decodable {
     var title: String
     var notes: String?
 }
 
-/// The context used for generating task suggestions.
+/// The context used for generating wish suggestions.
 struct SuggestionContext: Sendable {
     /// Free-form text describing the user's situation.
     var text: String
 }
 
-/// Service that generates task suggestions using an on-device foundation model.
+/// Service that generates wish suggestions using an on-device foundation model.
 @MainActor
 final class AISuggestionService {
     static let shared = AISuggestionService()
@@ -31,10 +31,10 @@ final class AISuggestionService {
         }
     }
 
-    /// Generates task suggestions for the provided context.
-    func suggestTasks(for context: SuggestionContext) async throws -> [Wish] {
+    /// Generates wish suggestions for the provided context.
+    func suggestWishes(for context: SuggestionContext) async throws -> [Wish] {
         let prompt = promptTemplate.replacingOccurrences(of: "{{context}}", with: context.text)
-        let response = try await session.respond(to: prompt, generating: [TaskSuggestion].self)
+        let response = try await session.respond(to: prompt, generating: [WishSuggestion].self)
         return response.content.map { Wish(title: $0.title, notes: $0.notes) }
     }
 }

--- a/Wishle/Sources/Shared/Models/OnboardingFlow.swift
+++ b/Wishle/Sources/Shared/Models/OnboardingFlow.swift
@@ -13,7 +13,7 @@ struct SwipeToCompleteTip: Tip {
         Text("Swipe to complete")
     }
     var message: Text? {
-        Text("Swipe a task to mark it completed.")
+        Text("Swipe a wish to mark it completed.")
     }
 }
 
@@ -22,7 +22,7 @@ struct LongPressQuickEditTip: Tip {
         Text("Long-press for quick edit")
     }
     var message: Text? {
-        Text("Long press on a task to edit it.")
+        Text("Long press on a wish to edit it.")
     }
 }
 

--- a/Wishle/Sources/Wish/Intents/AddWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/AddWishIntent.swift
@@ -1,5 +1,5 @@
 //
-//  AddTaskIntent.swift
+//  AddWishIntent.swift
 //  Wishle
 //
 //  Created by Hiromu Nakano on 2025/06/17.
@@ -9,11 +9,11 @@ import AppIntents
 import SwiftData
 import SwiftUtilities
 
-struct AddTaskIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Add Task"
+struct AddWishIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource = "Add Wish"
 
     /// Service injected from the application context.
-    var service: TaskServiceProtocol = TaskService.shared
+    var service: WishServiceProtocol = WishService.shared
     @Dependency private var modelContainer: ModelContainer
 
     @Parameter(title: "Title")
@@ -41,19 +41,19 @@ struct AddTaskIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) async throws -> Wish {
         let (context, title, notes, dueDate, priority) = input
-        let service = TaskService(modelContext: context)
-        return try await service.addTask(title: title, notes: notes, dueDate: dueDate, priority: priority)
+        let service = WishService(modelContext: context)
+        return try await service.addWish(title: title, notes: notes, dueDate: dueDate, priority: priority)
     }
 
     @MainActor
     func perform() async throws -> some ReturnsValue<String> {
-        let task = try await Self.perform((
+        let wish = try await Self.perform((
             context: modelContainer.mainContext,
             title: title,
             notes: notes,
             dueDate: dueDate,
             priority: priority
         ))
-        return .result(value: task.title)
+        return .result(value: wish.title)
     }
 }

--- a/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
@@ -1,5 +1,5 @@
 //
-//  DeleteTaskIntent.swift
+//  DeleteWishIntent.swift
 //  Wishle
 //
 //  Created by Hiromu Nakano on 2025/06/17.
@@ -9,18 +9,18 @@ import AppIntents
 import SwiftData
 import SwiftUtilities
 
-struct DeleteTaskIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Delete Task"
+struct DeleteWishIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource = "Delete Wish"
 
     /// Service injected from the application context.
-    var service: TaskServiceProtocol = TaskService.shared
+    var service: WishServiceProtocol = WishService.shared
     @Dependency private var modelContainer: ModelContainer
 
     @Parameter(title: "ID")
     private var id: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Delete task \(\.$id)")
+        Summary("Delete wish \(\.$id)")
     }
 
     typealias Input = (context: ModelContext, id: String)
@@ -28,11 +28,11 @@ struct DeleteTaskIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) async throws {
         let (context, id) = input
-        let service = TaskService(modelContext: context)
-        guard let task = service.task(id: id) else {
+        let service = WishService(modelContext: context)
+        guard let wish = service.wish(id: id) else {
             return
         }
-        try await service.deleteTask(task)
+        try await service.deleteWish(wish)
     }
 
     @MainActor

--- a/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
@@ -1,5 +1,5 @@
 //
-//  UpdateTaskIntent.swift
+//  UpdateWishIntent.swift
 //  Wishle
 //
 //  Created by Hiromu Nakano on 2025/06/17.
@@ -9,11 +9,11 @@ import AppIntents
 import SwiftData
 import SwiftUtilities
 
-struct UpdateTaskIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Update Task"
+struct UpdateWishIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource = "Update Wish"
 
     /// Service injected from the application context.
-    var service: TaskServiceProtocol = TaskService.shared
+    var service: WishServiceProtocol = WishService.shared
     @Dependency private var modelContainer: ModelContainer
 
     @Parameter(title: "ID")
@@ -35,7 +35,7 @@ struct UpdateTaskIntent: AppIntent, IntentPerformer {
     private var priority: Int?
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Update task \(\.$id)") {
+        Summary("Update wish \(\.$id)") {
             \.$title
             \.$notes
             \.$dueDate
@@ -49,16 +49,16 @@ struct UpdateTaskIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) async throws {
         let (context, id, title, notes, dueDate, isCompleted, priority) = input
-        let service = TaskService(modelContext: context)
-        guard var task = service.task(id: id) else {
+        let service = WishService(modelContext: context)
+        guard var wish = service.wish(id: id) else {
             return
         }
-        if let title { task.title = title }
-        if let notes { task.notes = notes }
-        if let dueDate { task.dueDate = dueDate }
-        if let isCompleted { task.isCompleted = isCompleted }
-        if let priority { task.priority = priority }
-        try await service.updateTask(task)
+        if let title { wish.title = title }
+        if let notes { wish.notes = notes }
+        if let dueDate { wish.dueDate = dueDate }
+        if let isCompleted { wish.isCompleted = isCompleted }
+        if let priority { wish.priority = priority }
+        try await service.updateWish(wish)
     }
 
     @MainActor

--- a/Wishle/Sources/Wish/Models/WishService.swift
+++ b/Wishle/Sources/Wish/Models/WishService.swift
@@ -1,5 +1,5 @@
 //
-//  TaskService.swift
+//  WishService.swift
 //  Wishle
 //
 //  Created by Hiromu Nakano on 2025/06/17.
@@ -9,32 +9,32 @@ import Foundation
 import SwiftData
 
 /// A protocol that defines operations for managing `Wish` instances.
-protocol TaskServiceProtocol {
-    /// Adds a new task and persists it.
-    /// - Returns: The created task instance.
-    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Wish
+protocol WishServiceProtocol {
+    /// Adds a new wish and persists it.
+    /// - Returns: The created wish instance.
+    func addWish(title: String, notes: String?, dueDate: Date?, priority: Int) async throws -> Wish
 
-    /// Finds a task for the given identifier.
-    func task(id: String) -> Wish?
+    /// Finds a wish for the given identifier.
+    func wish(id: String) -> Wish?
 
-    /// Persists updates to the provided task.
-    func updateTask(_ task: Wish) async throws
+    /// Persists updates to the provided wish.
+    func updateWish(_ wish: Wish) async throws
 
-    /// Deletes the task from persistence.
-    func deleteTask(_ task: Wish) async throws
+    /// Deletes the wish from persistence.
+    func deleteWish(_ wish: Wish) async throws
 
-    /// Returns the next task that is not completed, ordered by due date then priority.
-    func nextUpTask() -> Wish?
+    /// Returns the next wish that is not completed, ordered by due date then priority.
+    func nextUpWish() -> Wish?
 
     /// Underlying SwiftData context for advanced operations.
     var context: ModelContext { get }
 }
 
-/// Default implementation of ``TaskServiceProtocol`` using SwiftData.
+/// Default implementation of ``WishServiceProtocol`` using SwiftData.
 @MainActor
-final class TaskService: TaskServiceProtocol {
+final class WishService: WishServiceProtocol {
     /// Shared singleton instance used when no dependency is injected.
-    static var shared: TaskService = {
+    static var shared: WishService = {
         do {
             let schema = Schema([
                 WishModel.self,
@@ -59,7 +59,7 @@ final class TaskService: TaskServiceProtocol {
         self.modelContext = modelContext
     }
 
-    func task(id: String) -> Wish? {
+    func wish(id: String) -> Wish? {
         let id = id
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
         guard let model = try? modelContext.fetch(descriptor).first else {
@@ -68,7 +68,7 @@ final class TaskService: TaskServiceProtocol {
         return model.wish
     }
 
-    func addTask(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish {
+    func addWish(title: String, notes: String?, dueDate: Date?, priority: Int) throws -> Wish {
         let model = WishModel(
             title: title,
             notes: notes,
@@ -80,25 +80,25 @@ final class TaskService: TaskServiceProtocol {
         return model.wish
     }
 
-    func updateTask(_ task: Wish) throws {
-        let id = task.id
+    func updateWish(_ wish: Wish) throws {
+        let id = wish.id
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
         guard let model = try modelContext.fetch(descriptor).first else {
             return
         }
 
-        model.title = task.title
-        model.notes = task.notes
-        model.dueDate = task.dueDate
-        model.isCompleted = task.isCompleted
-        model.priority = task.priority
+        model.title = wish.title
+        model.notes = wish.notes
+        model.dueDate = wish.dueDate
+        model.isCompleted = wish.isCompleted
+        model.priority = wish.priority
         model.updatedAt = .now
-        model.tags = task.tags.map(TagModel.init)
+        model.tags = wish.tags.map(TagModel.init)
         try modelContext.save()
     }
 
-    func deleteTask(_ task: Wish) throws {
-        let id = task.id
+    func deleteWish(_ wish: Wish) throws {
+        let id = wish.id
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
         if let model = try modelContext.fetch(descriptor).first {
             modelContext.delete(model)
@@ -106,13 +106,13 @@ final class TaskService: TaskServiceProtocol {
         try modelContext.save()
     }
 
-    func nextUpTask() -> Wish? {
+    func nextUpWish() -> Wish? {
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { !$0.isCompleted })
         guard let models = try? modelContext.fetch(descriptor) else {
             return nil
         }
-        let tasks = models.map(\.wish)
-        return tasks.sorted { lhs, rhs in
+        let wishes = models.map(\.wish)
+        return wishes.sorted { lhs, rhs in
             switch (lhs.dueDate, rhs.dueDate) {
             case let (lhsDate?, rhsDate?):
                 if lhsDate != rhsDate {

--- a/WishleTests/AISuggestionServiceTests.swift
+++ b/WishleTests/AISuggestionServiceTests.swift
@@ -3,9 +3,9 @@ import Testing
 
 struct AISuggestionServiceTests {
     @Test
-    func testSuggestTasks() async throws {
+    func testSuggestWishes() async throws {
         let service = AISuggestionService(randomProvider: SeededRandomProvider(seed: 42))
-        let tasks = try await service.suggestTasks(for: .init(text: "Plan a weekend getaway"))
-        #expect(!tasks.isEmpty)
+        let wishes = try await service.suggestWishes(for: .init(text: "Plan a weekend getaway"))
+        #expect(!wishes.isEmpty)
     }
 }

--- a/WishleWidget/NextUp/NextUpLiveActivity.swift
+++ b/WishleWidget/NextUp/NextUpLiveActivity.swift
@@ -14,14 +14,14 @@ struct NextUpLiveActivityAttributes: ActivityAttributes {
         var remainingTime: TimeInterval
     }
 
-    var taskID: UUID
+    var wishID: UUID
 }
 
 struct NextUpLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: NextUpLiveActivityAttributes.self) { context in
             VStack(alignment: .leading) {
-                Text("Next Task")
+                Text("Next Wish")
                 Text(
                     timerInterval: Date()...Date().addingTimeInterval(context.state.remainingTime),
                     countsDown: true
@@ -53,7 +53,7 @@ struct NextUpLiveActivity: Widget {
 #if DEBUG
 extension NextUpLiveActivityAttributes {
     fileprivate static var preview: NextUpLiveActivityAttributes {
-        .init(taskID: .init())
+        .init(wishID: .init())
     }
 }
 

--- a/WishleWidget/NextUp/NextUpWidget.swift
+++ b/WishleWidget/NextUp/NextUpWidget.swift
@@ -11,16 +11,16 @@ import WidgetKit
 
 struct NextUpProvider: TimelineProvider {
     func placeholder(in _: Context) -> NextUpEntry {
-        .init(date: .now, task: .placeholder)
+        .init(date: .now, wish: .placeholder)
     }
 
     func getSnapshot(in _: Context, completion: @escaping (NextUpEntry) -> Void) {
-        completion(.init(date: .now, task: .placeholder))
+        completion(.init(date: .now, wish: .placeholder))
     }
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<NextUpEntry>) -> Void) {
-        let task = TaskDataStore.shared.nextUpTask()
-        let entry = NextUpEntry(date: .now, task: task)
+        let wish = WishDataStore.shared.nextUpWish()
+        let entry = NextUpEntry(date: .now, wish: wish)
         let timeline = Timeline(entries: [entry], policy: .after(.now.advanced(by: 60 * 15)))
         completion(timeline)
     }
@@ -28,7 +28,7 @@ struct NextUpProvider: TimelineProvider {
 
 struct NextUpEntry: TimelineEntry {
     let date: Date
-    let task: WidgetTask?
+    let wish: WidgetWish?
 }
 
 struct NextUpWidgetEntryView: View {
@@ -47,15 +47,15 @@ struct NextUpWidgetEntryView: View {
 
     private var content: some View {
         VStack(alignment: .leading) {
-            if let task = entry.task {
-                Text(task.title)
+            if let wish = entry.wish {
+                Text(wish.title)
                     .font(.headline)
-                if let dueDate = task.dueDate {
+                if let dueDate = wish.dueDate {
                     Text(dueDate, style: .date)
                         .font(.caption)
                 }
             } else {
-                Text("No tasks")
+                Text("No wishes")
             }
         }
     }
@@ -68,7 +68,7 @@ struct NextUpWidget: Widget {
         }
         .supportedFamilies([.systemSmall, .accessoryInline])
         .configurationDisplayName("Next Up")
-        .description("Shows your next uncompleted task")
+        .description("Shows your next uncompleted wish")
     }
 }
 
@@ -76,6 +76,6 @@ struct NextUpWidget: Widget {
 #Preview(as: .systemSmall) {
     NextUpWidget()
 } timeline: {
-    NextUpEntry(date: .now, task: .placeholder)
+    NextUpEntry(date: .now, wish: .placeholder)
 }
 #endif

--- a/WishleWidget/NextUp/WidgetWish.swift
+++ b/WishleWidget/NextUp/WidgetWish.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-struct WidgetTask: Identifiable, Codable, Hashable {
+struct WidgetWish: Identifiable, Codable, Hashable {
     var id: UUID
     var title: String
     var dueDate: Date?
     var priority: Int
 }
 
-extension WidgetTask {
-    static var placeholder: WidgetTask {
+extension WidgetWish {
+    static var placeholder: WidgetWish {
         .init(id: .init(), title: "Sample", dueDate: .now.addingTimeInterval(3_600), priority: 0)
     }
 }

--- a/WishleWidget/NextUp/WishDataStore.swift
+++ b/WishleWidget/NextUp/WishDataStore.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-struct TaskDataStore {
+struct WishDataStore {
     static let shared = Self()
 
     private let defaults = UserDefaults(suiteName: "group.com.muhiro12.wishle")
-    private let key = "nextUpTask"
+    private let key = "nextUpWish"
 
-    func nextUpTask() -> WidgetTask? {
+    func nextUpWish() -> WidgetWish? {
         guard let defaults, let data = defaults.data(forKey: key) else {
             return nil
         }
-        return try? JSONDecoder().decode(WidgetTask.self, from: data)
+        return try? JSONDecoder().decode(WidgetWish.self, from: data)
     }
 }


### PR DESCRIPTION
## Summary
- rename `TaskService` and related intents to `WishService`
- adjust importer/exporter and suggestion service APIs
- rename widget types and datastore to `Wish`
- update onboarding text and tests

## Testing
- `swiftlint` *(fails: command not found)*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f6ba66d0832095fa000371b420b5