### PR TITLE
Update ImportRemindersIntent input

### DIFF
--- a/Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift
+++ b/Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift
@@ -14,17 +14,17 @@ struct ImportRemindersIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = RemindersImporter
+    typealias Input = ModelContext
     typealias Output = Void
 
-    static func perform(_ input: RemindersImporter) async throws {
-        try await input.import()
+    static func perform(_ context: ModelContext) async throws {
+        let importer: RemindersImporter = .init(modelContext: context)
+        try await importer.import()
     }
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        let importer: RemindersImporter = .init(modelContext: modelContainer.mainContext)
-        try await Self.perform(importer)
+        try await Self.perform(modelContainer.mainContext)
         return .result()
     }
 }


### PR DESCRIPTION
## Summary
- adjust the static `perform` signature in `ImportRemindersIntent`
- construct the importer within the method

## Testing
- `swiftlint` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854233f40a08320a76303b1cfbaaaba