### PR TITLE
Add chat interface for Wish AppIntents

### DIFF
--- a/Wishle/Sources/Chat/ChatMessage.swift
+++ b/Wishle/Sources/Chat/ChatMessage.swift
@@ -1,0 +1,14 @@
+//
+//  ChatMessage.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/19.
+
+import Foundation
+
+struct ChatMessage: Identifiable, Hashable {
+    var id: String = UUID().uuidString
+    var text: String
+    var isUser: Bool
+}
+

--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -1,0 +1,90 @@
+//
+//  ChatView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/19.
+
+import SwiftData
+import SwiftUI
+
+struct ChatView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var messages: [ChatMessage] = []
+    @State private var inputText: String = ""
+
+    var body: some View {
+        VStack {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(messages) { message in
+                            chatBubble(for: message)
+                                .id(message.id)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                }
+                .onChange(of: messages.count) { _ in
+                    if let last = messages.last?.id {
+                        withAnimation {
+                            proxy.scrollTo(last, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            Divider()
+            HStack {
+                TextField("Enter wish", text: $inputText)
+                    .textFieldStyle(.roundedBorder)
+                Button("Send") { send() }
+                    .disabled(inputText.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            .padding()
+        }
+    }
+
+    private func chatBubble(for message: ChatMessage) -> some View {
+        HStack {
+            if message.isUser { Spacer() }
+            Text(message.text)
+                .padding(8)
+                .background(message.isUser ? Color.accentColor.opacity(0.2) : Color.gray.opacity(0.2))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            if !message.isUser { Spacer() }
+        }
+    }
+
+    private func send() {
+        let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let userMessage = .init(text: trimmed, isUser: true)
+        messages.append(userMessage)
+        inputText = ""
+
+        Task {
+            let wish = try? await AddWishIntent.perform((
+                context: modelContext,
+                title: trimmed,
+                notes: nil,
+                dueDate: nil,
+                priority: 0
+            ))
+            let responseText: String
+            if let wish {
+                responseText = "Added: \(wish.title)"
+            } else {
+                responseText = "Failed to add wish"
+            }
+            let botMessage = .init(text: responseText, isUser: false)
+            messages.append(botMessage)
+        }
+    }
+}
+
+#Preview {
+    ChatView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}
+

--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -59,7 +59,7 @@ struct ChatView: View {
     private func send() {
         let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        let userMessage = .init(text: trimmed, isUser: true)
+        let userMessage = ChatMessage(text: trimmed, isUser: true)
         messages.append(userMessage)
         inputText = ""
 
@@ -77,7 +77,7 @@ struct ChatView: View {
             } else {
                 responseText = "Failed to add wish"
             }
-            let botMessage = .init(text: responseText, isUser: false)
+            let botMessage = ChatMessage(text: responseText, isUser: false)
             messages.append(botMessage)
         }
     }
@@ -87,4 +87,3 @@ struct ChatView: View {
     ChatView()
         .modelContainer(for: WishModel.self, inMemory: true)
 }
-

--- a/Wishle/Sources/Management/AddWishView.swift
+++ b/Wishle/Sources/Management/AddWishView.swift
@@ -1,0 +1,65 @@
+//
+//  AddWishView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/19.
+//
+
+import SwiftData
+import SwiftUI
+
+struct AddWishView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var title: String = ""
+    @State private var notes: String = ""
+    @State private var priority: Int = 0
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Title", text: $title)
+                }
+                Section("Notes") {
+                    TextField("Notes", text: $notes)
+                }
+                Section("Priority") {
+                    Stepper(value: $priority, in: 0...1) {
+                        Text(priority == 0 ? "Normal" : "High")
+                    }
+                }
+            }
+            .navigationTitle("Add Wish")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        Task {
+            try? await AddWishIntent.perform((
+                context: modelContext,
+                title: title,
+                notes: notes.isEmpty ? nil : notes,
+                dueDate: nil,
+                priority: priority
+            ))
+            dismiss()
+        }
+    }
+}
+
+#Preview {
+    AddWishView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}
+

--- a/Wishle/Sources/Management/EditWishView.swift
+++ b/Wishle/Sources/Management/EditWishView.swift
@@ -73,10 +73,9 @@ struct EditWishView: View {
 }
 
 #Preview {
-    let container = try? ModelContainer(for: WishModel.self)
+    let container = try! ModelContainer(for: WishModel.self)
     let sample = WishModel(title: "Sample")
-    container?.mainContext.insert(sample)
+    container.mainContext.insert(sample)
     return EditWishView(wishModel: sample)
-        .modelContainer(container ?? .init())
+        .modelContainer(container)
 }
-

--- a/Wishle/Sources/Management/EditWishView.swift
+++ b/Wishle/Sources/Management/EditWishView.swift
@@ -1,0 +1,82 @@
+//
+//  EditWishView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/19.
+//
+
+import SwiftData
+import SwiftUI
+
+struct EditWishView: View {
+    let wishModel: WishModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var title: String
+    @State private var notes: String
+    @State private var isCompleted: Bool
+    @State private var priority: Int
+
+    init(wishModel: WishModel) {
+        self.wishModel = wishModel
+        _title = State(initialValue: wishModel.title)
+        _notes = State(initialValue: wishModel.notes ?? "")
+        _isCompleted = State(initialValue: wishModel.isCompleted)
+        _priority = State(initialValue: wishModel.priority)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Title") {
+                    TextField("Title", text: $title)
+                }
+                Section("Notes") {
+                    TextField("Notes", text: $notes)
+                }
+                Section("Completed") {
+                    Toggle("Completed", isOn: $isCompleted)
+                }
+                Section("Priority") {
+                    Stepper(value: $priority, in: 0...1) {
+                        Text(priority == 0 ? "Normal" : "High")
+                    }
+                }
+            }
+            .navigationTitle("Edit Wish")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                }
+            }
+        }
+    }
+
+    private func save() {
+        Task {
+            try? await UpdateWishIntent.perform((
+                context: modelContext,
+                id: wishModel.id,
+                title: title,
+                notes: notes.isEmpty ? nil : notes,
+                dueDate: nil,
+                isCompleted: isCompleted,
+                priority: priority
+            ))
+            dismiss()
+        }
+    }
+}
+
+#Preview {
+    let container = try? ModelContainer(for: WishModel.self)
+    let sample = WishModel(title: "Sample")
+    container?.mainContext.insert(sample)
+    return EditWishView(wishModel: sample)
+        .modelContainer(container ?? .init())
+}
+

--- a/Wishle/Sources/Management/MainTabView.swift
+++ b/Wishle/Sources/Management/MainTabView.swift
@@ -1,0 +1,29 @@
+//
+//  MainTabView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/19.
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            ChatView()
+                .tabItem {
+                    Label("Chat", systemImage: "bubble.left.and.bubble.right")
+                }
+            WishListView()
+                .tabItem {
+                    Label("Wishes", systemImage: "list.bullet")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}
+

--- a/Wishle/Sources/Management/MainTabView.swift
+++ b/Wishle/Sources/Management/MainTabView.swift
@@ -5,6 +5,7 @@
 //  Created by Codex on 2025/06/19.
 //
 
+import SwiftData
 import SwiftUI
 
 struct MainTabView: View {
@@ -26,4 +27,3 @@ struct MainTabView: View {
     MainTabView()
         .modelContainer(for: WishModel.self, inMemory: true)
 }
-

--- a/Wishle/Sources/Management/WishListView.swift
+++ b/Wishle/Sources/Management/WishListView.swift
@@ -1,0 +1,80 @@
+//
+//  WishListView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/19.
+//
+
+import SwiftData
+import SwiftUI
+
+struct WishListView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \WishModel.createdAt) private var wishes: [WishModel]
+
+    @State private var isPresentingAddSheet: Bool = false
+    @State private var editingWish: WishModel?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(wishes) { model in
+                    Button {
+                        editingWish = model
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(model.title)
+                                if let notes = model.notes {
+                                    Text(notes)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            Spacer()
+                            if model.isCompleted {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                            }
+                        }
+                    }
+                }
+                .onDelete(perform: delete)
+            }
+            .navigationTitle("Wishes")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        isPresentingAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $isPresentingAddSheet) {
+                AddWishView()
+            }
+            .sheet(item: $editingWish) { model in
+                EditWishView(wishModel: model)
+            }
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        for index in offsets {
+            let model = wishes[index]
+            Task {
+                try? await DeleteWishIntent.perform((
+                    context: modelContext,
+                    id: model.id
+                ))
+            }
+        }
+    }
+}
+
+#Preview {
+    WishListView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}
+

--- a/Wishle/Sources/WishleApp.swift
+++ b/Wishle/Sources/WishleApp.swift
@@ -15,7 +15,8 @@ struct WishleApp: App {
 
     var sharedModelContainer: ModelContainer {
         let schema = Schema([
-            Item.self
+            WishModel.self,
+            TagModel.self
         ])
         let configuration: ModelConfiguration
         if subscriptionManager.isSubscribed {
@@ -34,7 +35,7 @@ struct WishleApp: App {
     var body: some Scene {
         WindowGroup {
             if UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
-                ContentView()
+                MainTabView()
                     .sheet(isPresented: $isPaywallPresented) {
                         PaywallView()
                     }


### PR DESCRIPTION
## Summary
- add chat UI and new tab-based interface for Intents
- integrate add/edit/delete flows for wishes with SwiftData
- wire tab interface in `WishleApp`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685486599c9083208a671d26551bba20