### PR TITLE
Add settings screen and remove startup paywall

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Wishle is a lightweight task manager that focuses on what you **wish** to accomp
 - SwiftData storage with optional iCloud sync
 - Widgets including "Next Up" to highlight your upcoming task
 - Foundation model integration for on-device suggestions
+- In-app settings screen with subscription management and reminders import
 
 ## Requirements
 

--- a/Wishle/Sources/Management/MainTabView.swift
+++ b/Wishle/Sources/Management/MainTabView.swift
@@ -19,6 +19,10 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Wishes", systemImage: "list.bullet")
                 }
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gearshape")
+                }
         }
     }
 }

--- a/Wishle/Sources/Management/SettingsView.swift
+++ b/Wishle/Sources/Management/SettingsView.swift
@@ -1,0 +1,59 @@
+//
+//  SettingsView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/21.
+//
+
+import SwiftData
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var subscriptionManager = SubscriptionManager.shared
+    @State private var isPaywallPresented = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Subscription") {
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        Text(subscriptionManager.isSubscribed ? "Active" : "Free")
+                            .foregroundColor(.secondary)
+                    }
+                    Button("Manage Subscription") {
+                        isPaywallPresented = true
+                    }
+                }
+                Section("Data") {
+                    Button("Import Reminders") {
+                        Task {
+                            try? await ImportRemindersIntent.perform(modelContext)
+                        }
+                    }
+                }
+                Section("About") {
+                    HStack {
+                        Text("Version")
+                        Spacer()
+                        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+            .sheet(isPresented: $isPaywallPresented) {
+                PaywallView()
+            }
+            .task {
+                await subscriptionManager.load()
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/Wishle/Sources/WishleApp.swift
+++ b/Wishle/Sources/WishleApp.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @main
 struct WishleApp: App {
     @State private var subscriptionManager = SubscriptionManager.shared
-    @State private var isPaywallPresented = false
 
     var sharedModelContainer: ModelContainer {
         let schema = Schema([
@@ -34,17 +33,15 @@ struct WishleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            if UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
-                MainTabView()
-                    .sheet(isPresented: $isPaywallPresented) {
-                        PaywallView()
-                    }
-                    .task {
-                        await subscriptionManager.load()
-                        isPaywallPresented = !subscriptionManager.isSubscribed
-                    }
-            } else {
-                OnboardingFlow()
+            Group {
+                if UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
+                    MainTabView()
+                } else {
+                    OnboardingFlow()
+                }
+            }
+            .task {
+                await subscriptionManager.load()
             }
         }
         .modelContainer(sharedModelContainer)


### PR DESCRIPTION
## Summary
- remove automatic paywall display on startup
- add new `SettingsView` with subscription management
- expose settings in tab bar
- document settings screen in README

## Testing
- `pre-commit run --files Wishle/Sources/Management/SettingsView.swift Wishle/Sources/Management/MainTabView.swift Wishle/Sources/WishleApp.swift README.md`
- `xcodebuild -list -project Wishle.xcodeproj`

------
https://chatgpt.com/codex/tasks/task_e_68549dff99dc8320a8260850ba770cd9