### PR TITLE
Fix control-flow style

### DIFF
--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -38,7 +38,9 @@ struct ChatView: View {
             HStack {
                 TextField("Enter wish", text: $inputText)
                     .textFieldStyle(.roundedBorder)
-                Button("Send") { send() }
+                Button("Send") {
+                    send()
+                }
                     .disabled(inputText.trimmingCharacters(in: .whitespaces).isEmpty)
             }
             .padding()
@@ -47,18 +49,24 @@ struct ChatView: View {
 
     private func chatBubble(for message: ChatMessage) -> some View {
         HStack {
-            if message.isUser { Spacer() }
+            if message.isUser {
+                Spacer()
+            }
             Text(message.text)
                 .padding(8)
                 .background(message.isUser ? Color.accentColor.opacity(0.2) : Color.gray.opacity(0.2))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
-            if !message.isUser { Spacer() }
+            if !message.isUser {
+                Spacer()
+            }
         }
     }
 
     private func send() {
         let trimmed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else {
+            return
+        }
         let userMessage = ChatMessage(text: trimmed, isUser: true)
         messages.append(userMessage)
         inputText = ""

--- a/Wishle/Sources/Management/AddWishView.swift
+++ b/Wishle/Sources/Management/AddWishView.swift
@@ -34,11 +34,15 @@ struct AddWishView: View {
             .navigationTitle("Add Wish")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        dismiss()
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") { save() }
-                        .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    Button("Save") {
+                        save()
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
             }
         }

--- a/Wishle/Sources/Management/EditWishView.swift
+++ b/Wishle/Sources/Management/EditWishView.swift
@@ -47,10 +47,14 @@ struct EditWishView: View {
             .navigationTitle("Edit Wish")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        dismiss()
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") { save() }
+                    Button("Save") {
+                        save()
+                    }
                 }
             }
         }

--- a/Wishle/Sources/Shared/Models/AISuggestionService.swift
+++ b/Wishle/Sources/Shared/Models/AISuggestionService.swift
@@ -35,6 +35,8 @@ final class AISuggestionService {
     func suggestWishes(for context: SuggestionContext) async throws -> [Wish] {
         let prompt = promptTemplate.replacingOccurrences(of: "{{context}}", with: context.text)
         let response = try await session.respond(to: prompt, generating: [WishSuggestion].self)
-        return response.content.map { Wish(title: $0.title, notes: $0.notes) }
+        return response.content.map { suggestion in
+            Wish(title: suggestion.title, notes: suggestion.notes)
+        }
     }
 }

--- a/Wishle/Sources/Shared/Models/OnboardingFlow.swift
+++ b/Wishle/Sources/Shared/Models/OnboardingFlow.swift
@@ -36,19 +36,25 @@ struct OnboardingFlow: View {
     var body: some View {
         TabView(selection: $selection) {
             page(title: "Welcome to Wishle", description: "Store what you wish to do, not what you must do.") {
-                Button("Next") { selection = 1 }
+                Button("Next") {
+                    selection = 1
+                }
             }
             .tag(0)
 
             page(title: nil, description: nil) {
                 TipView(swipeTip)
-                Button("Next") { selection = 2 }
+                Button("Next") {
+                    selection = 2
+                }
             }
             .tag(1)
 
             page(title: nil, description: nil) {
                 TipView(editTip)
-                Button("Get Started") { finish() }
+                Button("Get Started") {
+                    finish()
+                }
             }
             .tag(2)
         }

--- a/Wishle/Sources/Shared/Models/RemindersExporter.swift
+++ b/Wishle/Sources/Shared/Models/RemindersExporter.swift
@@ -43,7 +43,10 @@ struct RemindersExporter {
     }
 
     private func fetchOrCreateCalendar(name: String) throws -> EKCalendar {
-        if let calendar = eventStore.calendars(for: .reminder).first(where: { $0.title == name }) {
+        if let calendar = eventStore
+            .calendars(for: .reminder)
+            .first(where: { $0.title == name })
+        {
             return calendar
         }
         let calendar = EKCalendar(for: .reminder, eventStore: eventStore)

--- a/Wishle/Sources/Shared/Models/RemindersImporter.swift
+++ b/Wishle/Sources/Shared/Models/RemindersImporter.swift
@@ -26,7 +26,9 @@ struct RemindersImporter {
             let predicate = eventStore.predicateForReminders(in: [calendar])
             let reminders = try await fetchRemindersAsync(matching: predicate)
             for reminder in reminders {
-                guard let title = reminder.title else { continue }
+                guard let title = reminder.title else {
+                    continue
+                }
                 let dueDate = reminder.dueDateComponents?.date
                 let notes = reminder.notes
                 let priority = Int(reminder.priority)
@@ -64,7 +66,11 @@ struct RemindersImporter {
                     ))
                     // Update tags directly
                     let id = wish.id
-                    if let model = try? modelContext.fetch(FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })).first {
+                    if let model = try? modelContext.fetch(
+                        FetchDescriptor<WishModel>(predicate: #Predicate {
+                            $0.id == id
+                        })
+                    ).first {
                         model.tags.append(TagModel(tag))
                         try modelContext.save()
                     }
@@ -75,7 +81,9 @@ struct RemindersImporter {
 
     private func fetchOrCreateTag(name: String) throws -> Tag {
         let lowercasedName = name.lowercased()
-        let descriptor = FetchDescriptor<TagModel>(predicate: #Predicate { $0.name == lowercasedName })
+        let descriptor = FetchDescriptor<TagModel>(predicate: #Predicate {
+            $0.name == lowercasedName
+        })
         if let model = try modelContext.fetch(descriptor).first {
             return model.tag
         }
@@ -86,11 +94,17 @@ struct RemindersImporter {
     }
 
     private func findWish(for reminder: EKReminder, tag: Tag) throws -> Wish? {
-        guard let title = reminder.title else { return nil }
-        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.title == title })
+        guard let title = reminder.title else {
+            return nil
+        }
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate {
+            $0.title == title
+        })
         let models = try modelContext.fetch(descriptor)
         let dueDate = reminder.dueDateComponents?.date
-        return models.map(\.wish).first { $0.dueDate == dueDate && $0.tags.contains(tag) }
+        return models.map(\.wish).first { wish in
+            wish.dueDate == dueDate && wish.tags.contains(tag)
+        }
     }
 
     private func requestFullAccessToRemindersAsync() async throws {

--- a/Wishle/Sources/Shared/Models/SubscriptionManager.swift
+++ b/Wishle/Sources/Shared/Models/SubscriptionManager.swift
@@ -38,7 +38,9 @@ final class SubscriptionManager {
 
     // Purchase the subscription.
     func purchase() async throws {
-        guard let product else { return }
+        guard let product else {
+            return
+        }
         let result = try await product.purchase()
         switch result {
         case .success(let verification):

--- a/Wishle/Sources/Wish/Entities/Wish.swift
+++ b/Wishle/Sources/Wish/Entities/Wish.swift
@@ -31,7 +31,9 @@ struct Wish: Identifiable, Hashable {
 
     /// Returns true when the due date has passed and the wish is not completed.
     var isOverdue: Bool {
-        guard let dueDate else { return false }
+        guard let dueDate else {
+            return false
+        }
         return dueDate < .now && !isCompleted
     }
 

--- a/Wishle/Sources/Wish/Entities/WishModel.swift
+++ b/Wishle/Sources/Wish/Entities/WishModel.swift
@@ -33,7 +33,9 @@ final class WishModel: Identifiable, Hashable {
 
     /// Returns true when the due date has passed and the wish is not completed.
     var isOverdue: Bool {
-        guard let dueDate else { return false }
+        guard let dueDate else {
+            return false
+        }
         return dueDate < .now && !isCompleted
     }
 

--- a/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
@@ -26,7 +26,9 @@ struct DeleteWishIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) async throws {
         let (context, id) = input
-        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate {
+            $0.id == id
+        })
         guard let model = try context.fetch(descriptor).first else {
             return
         }

--- a/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
@@ -47,15 +47,27 @@ struct UpdateWishIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) async throws {
         let (context, id, title, notes, dueDate, isCompleted, priority) = input
-        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate { $0.id == id })
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate {
+            $0.id == id
+        })
         guard let model = try context.fetch(descriptor).first else {
             return
         }
-        if let title { model.title = title }
-        if let notes { model.notes = notes }
-        if let dueDate { model.dueDate = dueDate }
-        if let isCompleted { model.isCompleted = isCompleted }
-        if let priority { model.priority = priority }
+        if let title {
+            model.title = title
+        }
+        if let notes {
+            model.notes = notes
+        }
+        if let dueDate {
+            model.dueDate = dueDate
+        }
+        if let isCompleted {
+            model.isCompleted = isCompleted
+        }
+        if let priority {
+            model.priority = priority
+        }
         model.updatedAt = .now
         try context.save()
     }


### PR DESCRIPTION
## Summary
- format single-line control-flow statements
- format trailing closures on separate lines

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint --fix --format --strict` *(fails: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_6854b8fed0388320b84a126fbdfa2cef