### PR TITLE
Add debug screen and sample data generator

### DIFF
--- a/Wishle/Sources/Management/DebugView.swift
+++ b/Wishle/Sources/Management/DebugView.swift
@@ -1,0 +1,76 @@
+import SwiftData
+import SwiftUI
+
+struct DebugView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var isGenerateAlertPresented = false
+    @State private var isResetAlertPresented = false
+    @State private var isDeleteAlertPresented = false
+
+    var body: some View {
+        Form {
+            Section("Data") {
+                Button("Generate Sample Data") {
+                    isGenerateAlertPresented = true
+                }
+                .confirmationDialog(
+                    "Generate sample data?",
+                    isPresented: $isGenerateAlertPresented
+                ) {
+                    Button("Generate", role: .destructive) {
+                        Task {
+                            try? generateSampleData()
+                        }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                }
+
+                Button("Delete All Data") {
+                    isDeleteAlertPresented = true
+                }
+                .confirmationDialog(
+                    "Delete all data?",
+                    isPresented: $isDeleteAlertPresented
+                ) {
+                    Button("Delete", role: .destructive) {
+                        Task {
+                            try? deleteAllData()
+                        }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                }
+            }
+            Section("App") {
+                Button("Reset Onboarding") {
+                    isResetAlertPresented = true
+                }
+                .confirmationDialog(
+                    "Reset onboarding flow?",
+                    isPresented: $isResetAlertPresented
+                ) {
+                    Button("Reset", role: .destructive) {
+                        UserDefaults.standard.set(false, forKey: "hasSeenOnboarding")
+                    }
+                    Button("Cancel", role: .cancel) {}
+                }
+            }
+        }
+        .navigationTitle("Debug")
+    }
+
+    private func generateSampleData() throws {
+        let generator = SampleDataGenerator(modelContext: modelContext)
+        try generator.generate()
+    }
+
+    private func deleteAllData() throws {
+        let generator = SampleDataGenerator(modelContext: modelContext)
+        try generator.removeAll()
+    }
+}
+
+#Preview {
+    DebugView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}

--- a/Wishle/Sources/Management/SettingsView.swift
+++ b/Wishle/Sources/Management/SettingsView.swift
@@ -42,6 +42,11 @@ struct SettingsView: View {
                             .foregroundColor(.secondary)
                     }
                 }
+                Section("Debug") {
+                    NavigationLink("Debug Tools") {
+                        DebugView()
+                    }
+                }
             }
             .navigationTitle("Settings")
             .sheet(isPresented: $isPaywallPresented) {

--- a/Wishle/Sources/Shared/Models/SampleDataGenerator.swift
+++ b/Wishle/Sources/Shared/Models/SampleDataGenerator.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct SampleDataGenerator {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func generate() throws {
+        let tagModels = Tag.sample().map(TagModel.init)
+        for tag in tagModels {
+            modelContext.insert(tag)
+        }
+        for index in 1...5 {
+            let wish = WishModel(
+                title: "Sample Wish \(index)",
+                notes: "Sample note \(index)",
+                dueDate: Calendar.current.date(byAdding: .day, value: index, to: .now),
+                priority: index % 2,
+                tags: [tagModels[index % tagModels.count]]
+            )
+            modelContext.insert(wish)
+        }
+        try modelContext.save()
+    }
+
+    func removeAll() throws {
+        let wishes = try modelContext.fetch(FetchDescriptor<WishModel>())
+        for wish in wishes {
+            modelContext.delete(wish)
+        }
+        let tags = try modelContext.fetch(FetchDescriptor<TagModel>())
+        for tag in tags {
+            modelContext.delete(tag)
+        }
+        try modelContext.save()
+    }
+}


### PR DESCRIPTION
## Summary
- add a debug screen accessible from Settings
- provide buttons for generating sample data, clearing data and resetting onboarding
- implement `SampleDataGenerator` for creating and removing demo entries
- expose the debug screen from Settings

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854befe329483208ff7c3cfad2a5977