### PR TITLE
Add sample generation intents

### DIFF
--- a/Wishle/Sources/Management/MainTabView.swift
+++ b/Wishle/Sources/Management/MainTabView.swift
@@ -19,6 +19,10 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Wishes", systemImage: "list.bullet")
                 }
+            WishSuggestionView()
+                .tabItem {
+                    Label("Suggest", systemImage: "lightbulb")
+                }
             SettingsView()
                 .tabItem {
                     Label("Settings", systemImage: "gearshape")

--- a/Wishle/Sources/Management/WishSuggestionView.swift
+++ b/Wishle/Sources/Management/WishSuggestionView.swift
@@ -1,0 +1,73 @@
+import SwiftData
+import SwiftUI
+
+struct WishSuggestionView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var suggestion: String = ""
+    @State private var isLoading: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                if !suggestion.isEmpty {
+                    Text(suggestion)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                }
+                Button("Fetch Random Wish") {
+                    fetchRandom()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isLoading)
+
+                Button("Suggest From Random") {
+                    suggestFromRandom()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isLoading)
+
+                Button("Suggest From Recent") {
+                    suggestFromRecent()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isLoading)
+                Spacer()
+            }
+            .navigationTitle("Suggestions")
+            .padding()
+        }
+    }
+
+    private func fetchRandom() {
+        isLoading = true
+        Task {
+            let wish = try? FetchRandomWishIntent.perform(modelContext)
+            suggestion = wish?.title ?? ""
+            isLoading = false
+        }
+    }
+
+    private func suggestFromRandom() {
+        isLoading = true
+        Task {
+            let wish = try? await SuggestWishFromRandomIntent.perform(modelContext)
+            suggestion = wish?.title ?? ""
+            isLoading = false
+        }
+    }
+
+    private func suggestFromRecent() {
+        isLoading = true
+        Task {
+            let wish = try? await SuggestWishFromRecentIntent.perform(modelContext)
+            suggestion = wish?.title ?? ""
+            isLoading = false
+        }
+    }
+}
+
+#Preview {
+    WishSuggestionView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}

--- a/Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift
@@ -1,0 +1,37 @@
+//
+//  FetchRandomWishIntent.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/20.
+//
+
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct FetchRandomWishIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource = "Get Random Wish"
+
+    @Dependency private var modelContainer: ModelContainer
+
+    typealias Input = ModelContext
+    typealias Output = Wish
+
+    static func perform(_ context: ModelContext) throws -> Wish {
+        let models = try context.fetch(FetchDescriptor<WishModel>())
+        guard let model = models.randomElement() else {
+            throw NSError(
+                domain: "FetchRandomWishIntent",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "No wishes available"]
+            )
+        }
+        return model.wish
+    }
+
+    @MainActor
+    func perform() async throws -> some ReturnsValue<String> {
+        let wish = try await Self.perform(modelContainer.mainContext)
+        return .result(value: wish.title)
+    }
+}

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
@@ -1,0 +1,47 @@
+//
+//  SuggestWishFromRandomIntent.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/20.
+//
+
+import AppIntents
+import FoundationModels
+import SwiftData
+import SwiftUtilities
+
+@Generable
+private struct RandomWishSuggestion: Decodable {
+    var title: String
+    var notes: String?
+}
+
+struct SuggestWishFromRandomIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource = "Suggest Wish from Random"
+
+    @Dependency private var modelContainer: ModelContainer
+
+    typealias Input = ModelContext
+    typealias Output = Wish
+
+    static func perform(_ context: ModelContext) async throws -> Wish {
+        var samples: [Wish] = []
+        for _ in 0..<5 {
+            let wish = try FetchRandomWishIntent.perform(context)
+            samples.append(wish)
+        }
+        let prompt = samples.map { "- \($0.title)" }.joined(separator: "\n")
+        let session = LanguageModelSession()
+        let response = try await session.respond(
+            to: "Suggest a new wish based on these wishes:\n\(prompt)",
+            generating: RandomWishSuggestion.self
+        )
+        return Wish(title: response.content.title, notes: response.content.notes)
+    }
+
+    @MainActor
+    func perform() async throws -> some ReturnsValue<String> {
+        let wish = try await Self.perform(modelContainer.mainContext)
+        return .result(value: wish.title)
+    }
+}

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
@@ -1,0 +1,48 @@
+//
+//  SuggestWishFromRecentIntent.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/20.
+//
+
+import AppIntents
+import FoundationModels
+import SwiftData
+import SwiftUtilities
+
+@Generable
+private struct RecentWishSuggestion: Decodable {
+    var title: String
+    var notes: String?
+}
+
+struct SuggestWishFromRecentIntent: AppIntent, IntentPerformer {
+    static var title: LocalizedStringResource = "Suggest Wish from Recent"
+
+    @Dependency private var modelContainer: ModelContainer
+
+    typealias Input = ModelContext
+    typealias Output = Wish
+
+    static func perform(_ context: ModelContext) async throws -> Wish {
+        let descriptor = FetchDescriptor<WishModel>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)],
+            fetchLimit: 5
+        )
+        let models = try context.fetch(descriptor)
+        let recent = models.map(\.wish)
+        let prompt = recent.map { "- \($0.title)" }.joined(separator: "\n")
+        let session = LanguageModelSession()
+        let response = try await session.respond(
+            to: "Suggest a new wish based on these recent wishes:\n\(prompt)",
+            generating: RecentWishSuggestion.self
+        )
+        return Wish(title: response.content.title, notes: response.content.notes)
+    }
+
+    @MainActor
+    func perform() async throws -> some ReturnsValue<String> {
+        let wish = try await Self.perform(modelContainer.mainContext)
+        return .result(value: wish.title)
+    }
+}


### PR DESCRIPTION
## Summary
- add intent to fetch a random wish
- add intent to suggest a new wish from random samples
- add intent to suggest a new wish from recent items
- add view to trigger suggestion intents
- include new view in the main tab bar

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c11fecc483208b16fa4eb2e7b399