### PR TITLE
Reorder AppIntent declarations

### DIFF
--- a/Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift
+++ b/Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift
@@ -10,12 +10,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ImportRemindersIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Import Reminders"
+    typealias Input = ModelContext
+    typealias Output = Void
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Void
+    static var title: LocalizedStringResource = "Import Reminders"
 
     static func perform(_ context: ModelContext) async throws {
         let importer: RemindersImporter = .init(modelContext: context)

--- a/Wishle/Sources/Wish/Intents/AddWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/AddWishIntent.swift
@@ -10,9 +10,8 @@ import SwiftData
 import SwiftUtilities
 
 struct AddWishIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Add Wish"
-
-    @Dependency private var modelContainer: ModelContainer
+    typealias Input = (context: ModelContext, title: String, notes: String?, dueDate: Date?, priority: Int)
+    typealias Output = Wish
 
     @Parameter(title: "Title")
     private var title: String
@@ -26,6 +25,10 @@ struct AddWishIntent: AppIntent, IntentPerformer {
     @Parameter(title: "Priority", default: 0)
     private var priority: Int
 
+    @Dependency private var modelContainer: ModelContainer
+
+    static var title: LocalizedStringResource = "Add Wish"
+
     static var parameterSummary: some ParameterSummary {
         Summary("Add \(\.$title)") {
             \.$notes
@@ -33,9 +36,6 @@ struct AddWishIntent: AppIntent, IntentPerformer {
             \.$priority
         }
     }
-
-    typealias Input = (context: ModelContext, title: String, notes: String?, dueDate: Date?, priority: Int)
-    typealias Output = Wish
 
     static func perform(_ input: Input) throws -> Wish {
         let (context, title, notes, dueDate, priority) = input

--- a/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
@@ -10,19 +10,19 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteWishIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Delete Wish"
-
-    @Dependency private var modelContainer: ModelContainer
+    typealias Input = (context: ModelContext, id: String)
+    typealias Output = Void
 
     @Parameter(title: "ID")
     private var id: String
 
+    @Dependency private var modelContainer: ModelContainer
+
+    static var title: LocalizedStringResource = "Delete Wish"
+
     static var parameterSummary: some ParameterSummary {
         Summary("Delete wish \(\.$id)")
     }
-
-    typealias Input = (context: ModelContext, id: String)
-    typealias Output = Void
 
     static func perform(_ input: Input) throws {
         let (context, id) = input

--- a/Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift
@@ -10,12 +10,12 @@ import SwiftData
 import SwiftUtilities
 
 struct FetchRandomWishIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Get Random Wish"
+    typealias Input = ModelContext
+    typealias Output = Wish
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Wish
+    static var title: LocalizedStringResource = "Get Random Wish"
 
     static func perform(_ context: ModelContext) throws -> Wish {
         let models = try context.fetch(FetchDescriptor<WishModel>())

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
@@ -17,12 +17,12 @@ private struct RandomWishSuggestion: Decodable {
 }
 
 struct SuggestWishFromRandomIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Suggest Wish from Random"
+    typealias Input = ModelContext
+    typealias Output = Wish
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Wish
+    static var title: LocalizedStringResource = "Suggest Wish from Random"
 
     static func perform(_ context: ModelContext) async throws -> Wish {
         var samples: [Wish] = []

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
@@ -17,12 +17,12 @@ private struct RecentWishSuggestion: Decodable {
 }
 
 struct SuggestWishFromRecentIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Suggest Wish from Recent"
+    typealias Input = ModelContext
+    typealias Output = Wish
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Wish
+    static var title: LocalizedStringResource = "Suggest Wish from Recent"
 
     static func perform(_ context: ModelContext) async throws -> Wish {
         var descriptor = FetchDescriptor<WishModel>(

--- a/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
@@ -10,9 +10,8 @@ import SwiftData
 import SwiftUtilities
 
 struct UpdateWishIntent: AppIntent, IntentPerformer {
-    static var title: LocalizedStringResource = "Update Wish"
-
-    @Dependency private var modelContainer: ModelContainer
+    typealias Input = (context: ModelContext, id: String, title: String?, notes: String?, dueDate: Date?, isCompleted: Bool?, priority: Int?)
+    typealias Output = Void
 
     @Parameter(title: "ID")
     private var id: String
@@ -32,6 +31,10 @@ struct UpdateWishIntent: AppIntent, IntentPerformer {
     @Parameter(title: "Priority")
     private var priority: Int?
 
+    @Dependency private var modelContainer: ModelContainer
+
+    static var title: LocalizedStringResource = "Update Wish"
+
     static var parameterSummary: some ParameterSummary {
         Summary("Update wish \(\.$id)") {
             \.$title
@@ -41,9 +44,6 @@ struct UpdateWishIntent: AppIntent, IntentPerformer {
             \.$priority
         }
     }
-
-    typealias Input = (context: ModelContext, id: String, title: String?, notes: String?, dueDate: Date?, isCompleted: Bool?, priority: Int?)
-    typealias Output = Void
 
     static func perform(_ input: Input) throws {
         let (context, id, title, notes, dueDate, isCompleted, priority) = input


### PR DESCRIPTION
## Summary
- reorder declarations in all AppIntent files so `typealias`, `@Parameter`, `@Dependency`, `static var`, `var`, `static func`, `func`

## Testing
- `pre-commit run --files Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift Wishle/Sources/Wish/Intents/AddWishIntent.swift Wishle/Sources/Wish/Intents/DeleteWishIntent.swift Wishle/Sources/Wish/Intents/UpdateWishIntent.swift Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift` *(fails: command not found or fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68550ce14724832081cdff9074dbf530