### PR TITLE
Add wish and tag detail views

### DIFF
--- a/Wishle/Sources/Management/TagDetailView.swift
+++ b/Wishle/Sources/Management/TagDetailView.swift
@@ -1,0 +1,68 @@
+//
+//  TagDetailView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/22.
+//
+
+import SwiftData
+import SwiftUI
+
+struct TagDetailView: View {
+    @Environment(Tag.self) private var tag: Tag
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var wishes: [Wish] = []
+
+    var body: some View {
+        List {
+            if wishes.isEmpty {
+                Text("No wishes found.")
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(wishes, id: \.id) { wish in
+                    NavigationLink {
+                        WishDetailView()
+                            .environment(wish)
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(wish.title)
+                            if let notes = wish.notes {
+                                Text(notes)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(tag.name)
+        .task { loadWishes() }
+    }
+
+    private func loadWishes() {
+        let descriptor = FetchDescriptor<WishModel>()
+        if let models = try? modelContext.fetch(descriptor) {
+            wishes = models
+                .filter { model in
+                    model.tags.contains { $0.id == tag.id }
+                }
+                .map(\.wish)
+        }
+    }
+}
+
+#Preview {
+    let container = try! ModelContainer(for: WishModel.self)
+    let tag = TagModel(name: "home")
+    let wish = WishModel(title: "Sample", tags: [tag])
+    tag.wishes = [wish]
+    container.mainContext.insert(tag)
+    container.mainContext.insert(wish)
+    return NavigationStack {
+        TagDetailView()
+            .environment(tag.tag)
+    }
+    .modelContainer(container)
+}

--- a/Wishle/Sources/Management/WishDetailView.swift
+++ b/Wishle/Sources/Management/WishDetailView.swift
@@ -1,0 +1,78 @@
+//
+//  WishDetailView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/22.
+//
+
+import SwiftData
+import SwiftUI
+
+struct WishDetailView: View {
+    @Environment(Wish.self) private var wish: Wish
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var editingModel: WishModel?
+
+    var body: some View {
+        List {
+            if let notes = wish.notes {
+                Section("Notes") {
+                    Text(notes)
+                }
+            }
+            if let dueDate = wish.dueDate {
+                Section("Due Date") {
+                    Text(dueDate.formatted(date: .abbreviated, time: .shortened))
+                }
+            }
+            Section("Completed") {
+                Text(wish.isCompleted ? "Yes" : "No")
+            }
+            Section("Priority") {
+                Text(wish.priority == 0 ? "Normal" : "High")
+            }
+            if !wish.tags.isEmpty {
+                Section("Tags") {
+                    ForEach(wish.tags, id: \.id) { tag in
+                    NavigationLink {
+                        TagDetailView()
+                            .environment(tag)
+                    } label: {
+                            Text(tag.name)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(wish.title)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit") {
+                    loadModel()
+                }
+            }
+        }
+        .sheet(item: $editingModel) { model in
+            EditWishView(wishModel: model)
+        }
+    }
+
+    private func loadModel() {
+        let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate {
+            $0.id == wish.id
+        })
+        editingModel = try? modelContext.fetch(descriptor).first
+    }
+}
+
+#Preview {
+    let container = try! ModelContainer(for: WishModel.self)
+    let sample = WishModel(title: "Sample Wish")
+    container.mainContext.insert(sample)
+    return NavigationStack {
+        WishDetailView()
+            .environment(sample.wish)
+    }
+    .modelContainer(container)
+}

--- a/Wishle/Sources/Management/WishListView.swift
+++ b/Wishle/Sources/Management/WishListView.swift
@@ -19,8 +19,9 @@ struct WishListView: View {
         NavigationStack {
             List {
                 ForEach(wishes) { model in
-                    Button {
-                        editingWish = model
+                    NavigationLink {
+                        WishDetailView()
+                            .environment(model.wish)
                     } label: {
                         HStack {
                             VStack(alignment: .leading) {
@@ -36,6 +37,11 @@ struct WishListView: View {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundColor(.green)
                             }
+                        }
+                    }
+                    .contextMenu {
+                        Button("Edit") {
+                            editingWish = model
                         }
                     }
                 }

--- a/Wishle/Sources/Tag/Entities/Tag.swift
+++ b/Wishle/Sources/Tag/Entities/Tag.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// In-memory representation of a tag used to categorize wishes.
-struct Tag: Identifiable, Hashable {
+@Observable
+final class Tag: Identifiable, Hashable {
     /// Unique identifier for the tag.
     var id: String
     /// Lowercased unique name of the tag.

--- a/Wishle/Sources/Wish/Entities/Wish.swift
+++ b/Wishle/Sources/Wish/Entities/Wish.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// In-memory representation of a wish item.
-struct Wish: Identifiable, Hashable {
+@Observable
+final class Wish: Identifiable, Hashable {
     /// Unique identifier for the wish.
     var id: String
     /// The user-facing title.


### PR DESCRIPTION
## Summary
- make `Wish` and `Tag` final classes so they are `@Observable` without importing Observation
- remove the now unnecessary Observation import

## Testing
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685510e0b5488320a9957d5edda22d64