### PR TITLE
Add search tab with AppIntent

### DIFF
--- a/Wishle/Sources/Management/MainTabView.swift
+++ b/Wishle/Sources/Management/MainTabView.swift
@@ -19,6 +19,10 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Wishes", systemImage: "list.bullet")
                 }
+            WishSearchView()
+                .tabItem {
+                    Label("Search", systemImage: "magnifyingglass")
+                }
             WishSuggestionView()
                 .tabItem {
                     Label("Suggest", systemImage: "lightbulb")

--- a/Wishle/Sources/Management/WishSearchView.swift
+++ b/Wishle/Sources/Management/WishSearchView.swift
@@ -1,0 +1,51 @@
+//
+//  WishSearchView.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/21.
+//
+
+import SwiftData
+import SwiftUI
+
+struct WishSearchView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var query: String = ""
+    @State private var results: [Wish] = []
+
+    var body: some View {
+        NavigationStack {
+            List(results) { wish in
+                VStack(alignment: .leading) {
+                    Text(wish.title)
+                    if let notes = wish.notes {
+                        Text(notes)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Search")
+            .searchable(text: $query)
+            .onSubmit(of: .search) {
+                search()
+            }
+        }
+    }
+
+    private func search() {
+        Task {
+            do {
+                results = try SearchWishIntent.perform((context: modelContext, query: query))
+            } catch {
+                results = []
+            }
+        }
+    }
+}
+
+#Preview {
+    WishSearchView()
+        .modelContainer(for: WishModel.self, inMemory: true)
+}

--- a/Wishle/Sources/Wish/Intents/SearchWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SearchWishIntent.swift
@@ -1,0 +1,46 @@
+//
+//  SearchWishIntent.swift
+//  Wishle
+//
+//  Created by Codex on 2025/06/21.
+//
+
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct SearchWishIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, query: String)
+    typealias Output = [Wish]
+
+    @Parameter(title: "Query")
+    private var query: String
+
+    @Dependency private var modelContainer: ModelContainer
+
+    static var title: LocalizedStringResource = "Search Wishes"
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Search wishes for \(\.$query)")
+    }
+
+    static func perform(_ input: Input) throws -> [Wish] {
+        let (context, query) = input
+        var descriptor = FetchDescriptor<WishModel>(
+            predicate: #Predicate { model in
+                model.title.localizedStandardContains(query) ||
+                (model.notes ?? "").localizedStandardContains(query)
+            },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        descriptor.fetchLimit = 20
+        let models = try context.fetch(descriptor)
+        return models.map(\.wish)
+    }
+
+    @MainActor
+    func perform() throws -> some ReturnsValue<[Wish]> {
+        let wishes = try Self.perform((context: modelContainer.mainContext, query: query))
+        return .result(value: wishes)
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `SearchWishIntent` for searching wishes
- show search results in `WishSearchView`
- insert Search tab into `MainTabView`

## Testing
- `swiftlint` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68551a1beac483209ef54a827859eaaa