### PR TITLE
Switch Intents to use ModelContainer

### DIFF
--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -73,7 +73,7 @@ struct ChatView: View {
 
         Task {
             let wish = try? AddWishIntent.perform((
-                context: modelContext,
+                container: modelContext.container,
                 title: trimmed,
                 notes: nil,
                 dueDate: nil,

--- a/Wishle/Sources/Management/AddWishView.swift
+++ b/Wishle/Sources/Management/AddWishView.swift
@@ -51,7 +51,7 @@ struct AddWishView: View {
     private func save() {
         Task {
             _ = try? AddWishIntent.perform((
-                context: modelContext,
+                container: modelContext.container,
                 title: title,
                 notes: notes.isEmpty ? nil : notes,
                 dueDate: nil,

--- a/Wishle/Sources/Management/DebugView.swift
+++ b/Wishle/Sources/Management/DebugView.swift
@@ -60,12 +60,12 @@ struct DebugView: View {
     }
 
     private func generateSampleData() throws {
-        let generator = SampleDataGenerator(modelContext: modelContext)
+        let generator = SampleDataGenerator(modelContainer: modelContext.container)
         try generator.generate()
     }
 
     private func deleteAllData() throws {
-        let generator = SampleDataGenerator(modelContext: modelContext)
+        let generator = SampleDataGenerator(modelContainer: modelContext.container)
         try generator.removeAll()
     }
 }

--- a/Wishle/Sources/Management/EditWishView.swift
+++ b/Wishle/Sources/Management/EditWishView.swift
@@ -63,7 +63,7 @@ struct EditWishView: View {
     private func save() {
         Task {
             _ = try? UpdateWishIntent.perform((
-                context: modelContext,
+                container: modelContext.container,
                 id: wishModel.id,
                 title: title,
                 notes: notes.isEmpty ? nil : notes,

--- a/Wishle/Sources/Management/SettingsView.swift
+++ b/Wishle/Sources/Management/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsView: View {
                 Section("Data") {
                     Button("Import Reminders") {
                         Task {
-                            try? await ImportRemindersIntent.perform(modelContext)
+                            try? await ImportRemindersIntent.perform(modelContext.container)
                         }
                     }
                 }

--- a/Wishle/Sources/Management/WishListView.swift
+++ b/Wishle/Sources/Management/WishListView.swift
@@ -71,7 +71,7 @@ struct WishListView: View {
             let model = wishes[index]
             Task {
                 _ = try? DeleteWishIntent.perform((
-                    context: modelContext,
+                    container: modelContext.container,
                     id: model.id
                 ))
             }

--- a/Wishle/Sources/Management/WishSuggestionView.swift
+++ b/Wishle/Sources/Management/WishSuggestionView.swift
@@ -55,7 +55,7 @@ struct WishSuggestionView: View {
         isLoading = true
         Task {
             do {
-                let wish = try FetchRandomWishIntent.perform(modelContext)
+                let wish = try FetchRandomWishIntent.perform(modelContext.container)
                 suggestion = wish.title
             } catch {
                 errorMessage = error.localizedDescription
@@ -70,7 +70,7 @@ struct WishSuggestionView: View {
         isLoading = true
         Task {
             do {
-                let wish = try await SuggestWishFromRandomIntent.perform(modelContext)
+                let wish = try await SuggestWishFromRandomIntent.perform(modelContext.container)
                 suggestion = wish.title
             } catch {
                 errorMessage = error.localizedDescription
@@ -85,7 +85,7 @@ struct WishSuggestionView: View {
         isLoading = true
         Task {
             do {
-                let wish = try await SuggestWishFromRecentIntent.perform(modelContext)
+                let wish = try await SuggestWishFromRecentIntent.perform(modelContext.container)
                 suggestion = wish.title
             } catch {
                 errorMessage = error.localizedDescription

--- a/Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift
+++ b/Wishle/Sources/Shared/Intents/ImportRemindersIntent.swift
@@ -10,21 +10,21 @@ import SwiftData
 import SwiftUtilities
 
 struct ImportRemindersIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Void
 
     @Dependency private var modelContainer: ModelContainer
 
     static var title: LocalizedStringResource = "Import Reminders"
 
-    static func perform(_ context: ModelContext) async throws {
-        let importer: RemindersImporter = .init(modelContext: context)
+    static func perform(_ container: ModelContainer) async throws {
+        let importer: RemindersImporter = .init(modelContainer: container)
         try await importer.import()
     }
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        try await Self.perform(modelContainer.mainContext)
+        try await Self.perform(modelContainer)
         return .result()
     }
 }

--- a/Wishle/Sources/Shared/Models/RemindersExporter.swift
+++ b/Wishle/Sources/Shared/Models/RemindersExporter.swift
@@ -11,17 +11,17 @@ import SwiftData
 @MainActor
 struct RemindersExporter {
     private let eventStore: EKEventStore
-    private let modelContext: ModelContext
+    private let modelContainer: ModelContainer
 
     init(eventStore: EKEventStore = .init(),
-         modelContext: ModelContext) {
+         modelContainer: ModelContainer) {
         self.eventStore = eventStore
-        self.modelContext = modelContext
+        self.modelContainer = modelContainer
     }
 
     func export() async throws {
         try await eventStore.requestFullAccessToReminders()
-        let models = try modelContext.fetch(FetchDescriptor<WishModel>())
+        let models = try modelContainer.mainContext.fetch(FetchDescriptor<WishModel>())
         for model in models {
             let wish = model.wish
             for tag in wish.tags {

--- a/Wishle/Sources/Shared/Models/SampleDataGenerator.swift
+++ b/Wishle/Sources/Shared/Models/SampleDataGenerator.swift
@@ -3,16 +3,16 @@ import SwiftData
 
 @MainActor
 struct SampleDataGenerator {
-    private let modelContext: ModelContext
+    private let modelContainer: ModelContainer
 
-    init(modelContext: ModelContext) {
-        self.modelContext = modelContext
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
     }
 
     func generate() throws {
         let tagModels = Tag.sample().map(TagModel.init)
         for tag in tagModels {
-            modelContext.insert(tag)
+            modelContainer.mainContext.insert(tag)
         }
         for index in 1...5 {
             let wish = WishModel(
@@ -22,20 +22,20 @@ struct SampleDataGenerator {
                 priority: index % 2,
                 tags: [tagModels[index % tagModels.count]]
             )
-            modelContext.insert(wish)
+            modelContainer.mainContext.insert(wish)
         }
-        try modelContext.save()
+        try modelContainer.mainContext.save()
     }
 
     func removeAll() throws {
-        let wishes = try modelContext.fetch(FetchDescriptor<WishModel>())
+        let wishes = try modelContainer.mainContext.fetch(FetchDescriptor<WishModel>())
         for wish in wishes {
-            modelContext.delete(wish)
+            modelContainer.mainContext.delete(wish)
         }
-        let tags = try modelContext.fetch(FetchDescriptor<TagModel>())
+        let tags = try modelContainer.mainContext.fetch(FetchDescriptor<TagModel>())
         for tag in tags {
-            modelContext.delete(tag)
+            modelContainer.mainContext.delete(tag)
         }
-        try modelContext.save()
+        try modelContainer.mainContext.save()
     }
 }

--- a/Wishle/Sources/Wish/Intents/AddWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/AddWishIntent.swift
@@ -10,7 +10,7 @@ import SwiftData
 import SwiftUtilities
 
 struct AddWishIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, title: String, notes: String?, dueDate: Date?, priority: Int)
+    typealias Input = (container: ModelContainer, title: String, notes: String?, dueDate: Date?, priority: Int)
     typealias Output = Wish
 
     @Parameter(title: "Title")
@@ -38,7 +38,8 @@ struct AddWishIntent: AppIntent, IntentPerformer {
     }
 
     static func perform(_ input: Input) throws -> Wish {
-        let (context, title, notes, dueDate, priority) = input
+        let (container, title, notes, dueDate, priority) = input
+        let context = container.mainContext
         let model = WishModel(
             title: title,
             notes: notes,
@@ -53,7 +54,7 @@ struct AddWishIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ReturnsValue<String> {
         let wish = try Self.perform((
-            context: modelContainer.mainContext,
+            container: modelContainer,
             title: title,
             notes: notes,
             dueDate: dueDate,

--- a/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
@@ -10,7 +10,7 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteWishIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, id: String)
+    typealias Input = (container: ModelContainer, id: String)
     typealias Output = Void
 
     @Parameter(title: "ID")
@@ -25,7 +25,8 @@ struct DeleteWishIntent: AppIntent, IntentPerformer {
     }
 
     static func perform(_ input: Input) throws {
-        let (context, id) = input
+        let (container, id) = input
+        let context = container.mainContext
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate {
             $0.id == id
         })
@@ -39,7 +40,7 @@ struct DeleteWishIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some IntentResult {
         try Self.perform((
-            context: modelContainer.mainContext,
+            container: modelContainer,
             id: id
         ))
         return .result()

--- a/Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/FetchRandomWishIntent.swift
@@ -10,15 +10,15 @@ import SwiftData
 import SwiftUtilities
 
 struct FetchRandomWishIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Wish
 
     @Dependency private var modelContainer: ModelContainer
 
     static var title: LocalizedStringResource = "Get Random Wish"
 
-    static func perform(_ context: ModelContext) throws -> Wish {
-        let models = try context.fetch(FetchDescriptor<WishModel>())
+    static func perform(_ container: ModelContainer) throws -> Wish {
+        let models = try container.mainContext.fetch(FetchDescriptor<WishModel>())
         guard let model = models.randomElement() else {
             throw NSError(
                 domain: "FetchRandomWishIntent",
@@ -31,7 +31,7 @@ struct FetchRandomWishIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<String> {
-        let wish = try Self.perform(modelContainer.mainContext)
+        let wish = try Self.perform(modelContainer)
         return .result(value: wish.title)
     }
 }

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
@@ -17,17 +17,18 @@ private struct RandomWishSuggestion: Decodable {
 }
 
 struct SuggestWishFromRandomIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Wish
 
     @Dependency private var modelContainer: ModelContainer
 
     static var title: LocalizedStringResource = "Suggest Wish from Random"
 
-    static func perform(_ context: ModelContext) async throws -> Wish {
+    static func perform(_ container: ModelContainer) async throws -> Wish {
+        let context = container.mainContext
         var samples: [Wish] = []
         for _ in 0..<5 {
-            let wish = try FetchRandomWishIntent.perform(context)
+            let wish = try FetchRandomWishIntent.perform(container)
             samples.append(wish)
         }
         let prompt = samples.map { "- \($0.title)" }.joined(separator: "\n")
@@ -41,7 +42,7 @@ struct SuggestWishFromRandomIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() async throws -> some ReturnsValue<String> {
-        let wish = try await Self.perform(modelContainer.mainContext)
+        let wish = try await Self.perform(modelContainer)
         return .result(value: wish.title)
     }
 }

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
@@ -17,14 +17,15 @@ private struct RecentWishSuggestion: Decodable {
 }
 
 struct SuggestWishFromRecentIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Wish
 
     @Dependency private var modelContainer: ModelContainer
 
     static var title: LocalizedStringResource = "Suggest Wish from Recent"
 
-    static func perform(_ context: ModelContext) async throws -> Wish {
+    static func perform(_ container: ModelContainer) async throws -> Wish {
+        let context = container.mainContext
         var descriptor = FetchDescriptor<WishModel>(
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
@@ -42,7 +43,7 @@ struct SuggestWishFromRecentIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() async throws -> some ReturnsValue<String> {
-        let wish = try await Self.perform(modelContainer.mainContext)
+        let wish = try await Self.perform(modelContainer)
         return .result(value: wish.title)
     }
 }

--- a/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
@@ -10,7 +10,7 @@ import SwiftData
 import SwiftUtilities
 
 struct UpdateWishIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, id: String, title: String?, notes: String?, dueDate: Date?, isCompleted: Bool?, priority: Int?)
+    typealias Input = (container: ModelContainer, id: String, title: String?, notes: String?, dueDate: Date?, isCompleted: Bool?, priority: Int?)
     typealias Output = Void
 
     @Parameter(title: "ID")
@@ -46,7 +46,8 @@ struct UpdateWishIntent: AppIntent, IntentPerformer {
     }
 
     static func perform(_ input: Input) throws {
-        let (context, id, title, notes, dueDate, isCompleted, priority) = input
+        let (container, id, title, notes, dueDate, isCompleted, priority) = input
+        let context = container.mainContext
         let descriptor = FetchDescriptor<WishModel>(predicate: #Predicate {
             $0.id == id
         })
@@ -75,7 +76,7 @@ struct UpdateWishIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some IntentResult {
         try Self.perform((
-            context: modelContainer.mainContext,
+            container: modelContainer,
             id: id,
             title: title,
             notes: notes,


### PR DESCRIPTION
## Summary
- refactor all AppIntent performers to accept `ModelContainer`
- update models and generators to work with `ModelContainer`
- update views to call intents with the container

## Testing
- `swiftlint` *(fails: Loading libsourcekitdInProc.so)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865fb989d3c8320962242b2b177ad89