### PR TITLE
Improve sample data for Wish creation

### DIFF
--- a/Wishle/Sources/Management/EditWishView.swift
+++ b/Wishle/Sources/Management/EditWishView.swift
@@ -78,7 +78,7 @@ struct EditWishView: View {
 
 #Preview {
     let container = try! ModelContainer(for: WishModel.self)
-    let sample = WishModel(title: "Sample")
+    let sample = WishModel(title: "Plan a weekend trip")
     container.mainContext.insert(sample)
     return EditWishView(wishModel: sample)
         .modelContainer(container)

--- a/Wishle/Sources/Management/TagDetailView.swift
+++ b/Wishle/Sources/Management/TagDetailView.swift
@@ -55,8 +55,8 @@ struct TagDetailView: View {
 
 #Preview {
     let container = try! ModelContainer(for: WishModel.self)
-    let tag = TagModel(name: "home")
-    let wish = WishModel(title: "Sample", tags: [tag])
+    let tag = TagModel(name: "travel")
+    let wish = WishModel(title: "Plan a weekend trip", tags: [tag])
     tag.wishes = [wish]
     container.mainContext.insert(tag)
     container.mainContext.insert(wish)

--- a/Wishle/Sources/Management/WishDetailView.swift
+++ b/Wishle/Sources/Management/WishDetailView.swift
@@ -69,7 +69,7 @@ struct WishDetailView: View {
 
 #Preview {
     let container = try! ModelContainer(for: WishModel.self)
-    let sample = WishModel(title: "Sample Wish")
+    let sample = WishModel(title: "Plan a weekend trip")
     container.mainContext.insert(sample)
     return NavigationStack {
         WishDetailView()

--- a/Wishle/Sources/Shared/Models/SampleDataGenerator.swift
+++ b/Wishle/Sources/Shared/Models/SampleDataGenerator.swift
@@ -14,16 +14,51 @@ struct SampleDataGenerator {
         for tag in tagModels {
             modelContainer.mainContext.insert(tag)
         }
-        for index in 1...5 {
+
+        let wishes: [(String, String?, Int, [TagModel])] = [
+            (
+                "Plan a weekend trip to the mountains",
+                "Look up cabin rentals and hiking trails",
+                1,
+                [tagModels[0], tagModels[2]]
+            ),
+            (
+                "Try a new recipe for chocolate cake",
+                "Gather all ingredients and preheat the oven",
+                0,
+                [tagModels[1]]
+            ),
+            (
+                "Organize a board game night with friends",
+                "Create a chat group and pick a date",
+                0,
+                [tagModels[2]]
+            ),
+            (
+                "Start a small herb garden on the balcony",
+                "Buy seeds and planters for basil and mint",
+                1,
+                [tagModels[3], tagModels[2]]
+            ),
+            (
+                "Write a short story about a time traveler",
+                "Outline characters and key plot points",
+                0,
+                [tagModels[3]]
+            )
+        ]
+
+        for (offset, item) in wishes.enumerated() {
             let wish = WishModel(
-                title: "Sample Wish \(index)",
-                notes: "Sample note \(index)",
-                dueDate: Calendar.current.date(byAdding: .day, value: index, to: .now),
-                priority: index % 2,
-                tags: [tagModels[index % tagModels.count]]
+                title: item.0,
+                notes: item.1,
+                dueDate: Calendar.current.date(byAdding: .day, value: (offset + 1) * 3, to: .now),
+                priority: item.2,
+                tags: item.3
             )
             modelContainer.mainContext.insert(wish)
         }
+
         try modelContainer.mainContext.save()
     }
 

--- a/Wishle/Sources/Tag/Entities/Tag.swift
+++ b/Wishle/Sources/Tag/Entities/Tag.swift
@@ -36,9 +36,10 @@ final class Tag {
     /// Sample tags for preview usage.
     static func sample() -> [Tag] {
         [
-            .init(name: "home"),
-            .init(name: "work"),
-            .init(name: "urgent")
+            .init(name: "travel"),
+            .init(name: "food"),
+            .init(name: "personal"),
+            .init(name: "learning")
         ]
     }
 }

--- a/WishleWidget/NextUp/WidgetWish.swift
+++ b/WishleWidget/NextUp/WidgetWish.swift
@@ -9,6 +9,6 @@ struct WidgetWish: Identifiable, Codable, Hashable {
 
 extension WidgetWish {
     static var placeholder: WidgetWish {
-        .init(id: .init(), title: "Sample", dueDate: .now.addingTimeInterval(3_600), priority: 0)
+        .init(id: .init(), title: "Weekend trip", dueDate: .now.addingTimeInterval(3_600), priority: 0)
     }
 }


### PR DESCRIPTION
## Summary
- overhaul example wishes to feel more realistic
- replace sample tags to better match the new wishes
- update previews to use the new sample wish text
- tweak widget placeholder title

## Testing
- `pre-commit run --files Wishle/Sources/Management/EditWishView.swift Wishle/Sources/Management/TagDetailView.swift Wishle/Sources/Management/WishDetailView.swift Wishle/Sources/Shared/Models/SampleDataGenerator.swift Wishle/Sources/Tag/Entities/Tag.swift WishleWidget/NextUp/WidgetWish.swift` *(fails: command not found)*
- `swiftlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663c5671048320ad8dddd6be64cfa8