### PR TITLE
Enable editing AI suggestions

### DIFF
--- a/Wishle/Sources/Management/AddWishView.swift
+++ b/Wishle/Sources/Management/AddWishView.swift
@@ -12,9 +12,15 @@ struct AddWishView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var context
 
-    @State private var title: String = ""
-    @State private var notes: String = ""
-    @State private var priority: Int = 0
+    @State private var title: String
+    @State private var notes: String
+    @State private var priority: Int
+
+    init(title: String = "", notes: String = "", priority: Int = 0) {
+        _title = State(initialValue: title)
+        _notes = State(initialValue: notes)
+        _priority = State(initialValue: priority)
+    }
 
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
## Summary
- add initializer with defaults to `AddWishView`
- show a sheet in `WishSuggestionView` so generated wishes can be edited before saving

## Testing
- `pre-commit run --files Wishle/Sources/Management/AddWishView.swift Wishle/Sources/Management/WishSuggestionView.swift` *(fails: cannot fetch SwiftLint)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6867b4913cd88320867217974f55a816