### PR TITLE
Fix onboarding completion

### DIFF
--- a/Wishle/Sources/Shared/Models/OnboardingFlow.swift
+++ b/Wishle/Sources/Shared/Models/OnboardingFlow.swift
@@ -28,7 +28,7 @@ nonisolated struct LongPressQuickEditTip: Tip {
 
 struct OnboardingFlow: View {
     @State private var selection = 0
-    @Environment(\.dismiss) private var dismiss
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding: Bool = false
 
     private let swipeTip: SwipeToCompleteTip = .init()
     private let editTip: LongPressQuickEditTip = .init()
@@ -78,8 +78,7 @@ struct OnboardingFlow: View {
     }
 
     private func finish() {
-        UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
-        dismiss()
+        hasSeenOnboarding = true
     }
 }
 

--- a/Wishle/Sources/WishleApp.swift
+++ b/Wishle/Sources/WishleApp.swift
@@ -11,6 +11,7 @@ import SwiftUI
 @main
 struct WishleApp: App {
     @State private var subscriptionManager = SubscriptionManager.shared
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding: Bool = false
 
     var sharedModelContainer: ModelContainer {
         let schema = Schema([
@@ -34,7 +35,7 @@ struct WishleApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if UserDefaults.standard.bool(forKey: "hasSeenOnboarding") {
+                if hasSeenOnboarding {
                     MainTabView()
                 } else {
                     OnboardingFlow()


### PR DESCRIPTION
## Summary
- ensure onboarding flow can complete
- mark onboarding as seen via `@AppStorage`

## Testing
- `swiftlint` *(fails: Loading libsourcekitdInProc.so failed)*

------
https://chatgpt.com/codex/tasks/task_e_686907db54508320b307cb15f01f9765