### PR TITLE
Refactor update check as intent

### DIFF
--- a/Wishle/Sources/Configuration/Intents/CheckForUpdateIntent.swift
+++ b/Wishle/Sources/Configuration/Intents/CheckForUpdateIntent.swift
@@ -1,0 +1,23 @@
+import AppIntents
+import Foundation
+
+struct CheckForUpdateIntent: AppIntent, IntentPerformer {
+    typealias Output = Bool
+
+    nonisolated static let title: LocalizedStringResource = "Check for Update"
+
+    static func perform() async throws -> Bool {
+        let url = URL(string: "https://raw.githubusercontent.com/muhiro12/Wishle/main/.config.json")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let configuration = try JSONDecoder().decode(Configuration.self, from: data)
+        guard let current = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+              Bundle.main.bundleIdentifier?.contains("playgrounds") == false else {
+            return false
+        }
+        return current.compare(configuration.requiredVersion, options: .numeric) == .orderedAscending
+    }
+
+    func perform() async throws -> some ReturnsValue<Bool> {
+        .result(value: try await Self.perform())
+    }
+}

--- a/Wishle/Sources/ContentView.swift
+++ b/Wishle/Sources/ContentView.swift
@@ -15,7 +15,6 @@ struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var items: [Item]
 
-    @State private var configurationService = ConfigurationService.shared
     @State private var isUpdateAlertPresented = false
 
     var body: some View {
@@ -62,8 +61,7 @@ struct ContentView: View {
             Text("Please update Wishle to the latest version to continue using it.")
         }
         .task {
-            try? await configurationService.load()
-            isUpdateAlertPresented = configurationService.isUpdateRequired()
+            isUpdateAlertPresented = (try? await CheckForUpdateIntent.perform()) ?? false
         }
     }
 


### PR DESCRIPTION
## Summary
- add `CheckForUpdateIntent` to encapsulate remote config lookup
- update `ContentView` to use the new intent

## Testing
- `pre-commit run --files Wishle/Sources/Configuration/Intents/CheckForUpdateIntent.swift Wishle/Sources/ContentView.swift` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691f6a5d6483209ca4ce6b831dbcd0