### PR TITLE
Enable keyboard dismissal on scroll

### DIFF
--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -36,6 +36,7 @@ struct ChatView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
                 }
+                .scrollDismissesKeyboard(.interactively)
                 .onChange(of: messages.count) {
                     if let last = messages.last?.id {
                         withAnimation {

--- a/Wishle/Sources/ContentView.swift
+++ b/Wishle/Sources/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
                 }
                 .onDelete(perform: deleteItems)
             }
+            .scrollDismissesKeyboard(.interactively)
             #if os(macOS)
             .navigationSplitViewColumnWidth(min: 180, ideal: 200)
             #endif

--- a/Wishle/Sources/Management/AddWishView.swift
+++ b/Wishle/Sources/Management/AddWishView.swift
@@ -37,6 +37,7 @@ struct AddWishView: View {
                     }
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Add Wish")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/Wishle/Sources/Management/DebugView.swift
+++ b/Wishle/Sources/Management/DebugView.swift
@@ -56,6 +56,7 @@ struct DebugView: View {
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .navigationTitle("Debug")
     }
 

--- a/Wishle/Sources/Management/EditWishView.swift
+++ b/Wishle/Sources/Management/EditWishView.swift
@@ -44,6 +44,7 @@ struct EditWishView: View {
                     }
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Edit Wish")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/Wishle/Sources/Management/SettingsView.swift
+++ b/Wishle/Sources/Management/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
                     }
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Settings")
             .sheet(isPresented: $isPaywallPresented) {
                 PaywallView()

--- a/Wishle/Sources/Management/TagDetailView.swift
+++ b/Wishle/Sources/Management/TagDetailView.swift
@@ -37,6 +37,7 @@ struct TagDetailView: View {
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .navigationTitle(tag.name)
         .task { loadWishes() }
     }

--- a/Wishle/Sources/Management/WishDetailView.swift
+++ b/Wishle/Sources/Management/WishDetailView.swift
@@ -45,6 +45,7 @@ struct WishDetailView: View {
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .navigationTitle(wish.title)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/Wishle/Sources/Management/WishListView.swift
+++ b/Wishle/Sources/Management/WishListView.swift
@@ -75,6 +75,7 @@ struct WishListView: View {
                     }
                     .onDelete(perform: delete)
                 }
+                .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle("Wishes")
             .toolbar {

--- a/Wishle/Sources/Management/WishSuggestionView.swift
+++ b/Wishle/Sources/Management/WishSuggestionView.swift
@@ -82,6 +82,7 @@ struct WishSuggestionView: View {
                 }
                 .padding(.vertical)
             }
+            .scrollDismissesKeyboard(.interactively)
             .navigationTitle("Suggestions")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
## Summary
- hide the keyboard when scrolling
- apply scroll dismissal to several forms, lists and scroll views

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869233e4b6c8320b6c98af255f944f4