### PR TITLE
Enable message copying without UIKit

### DIFF
--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -77,6 +77,7 @@ struct ChatView: View {
                 Spacer()
             }
             Text(message.text)
+                .textSelection(.enabled)
                 .liquidGlass(cornerRadius: 20)
             if !message.isUser {
                 Spacer()


### PR DESCRIPTION
## Summary
- remove UIKit dependency from ChatView
- rely on SwiftUI's text selection for copying

## Testing
- `pre-commit run --files Wishle/Sources/Chat/ChatView.swift` *(fails: HTTP 403 when fetching SwiftLint)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686923c8543c83208cd850e899bd2b43