### PR TITLE
Improve completion interaction

### DIFF
--- a/Wishle/Sources/Management/WishListView.swift
+++ b/Wishle/Sources/Management/WishListView.swift
@@ -72,6 +72,17 @@ struct WishListView: View {
                                 editingWish = model
                             }
                         }
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                toggleCompletion(model)
+                            } label: {
+                                Label(
+                                    model.isCompleted ? "Mark Incomplete" : "Mark Complete",
+                                    systemImage: model.isCompleted ? "arrow.uturn.left" : "checkmark"
+                                )
+                            }
+                            .tint(model.isCompleted ? .orange : .green)
+                        }
                     }
                     .onDelete(perform: delete)
                 }
@@ -109,6 +120,21 @@ struct WishListView: View {
                     id: model.id
                 ))
             }
+        }
+    }
+
+    private func toggleCompletion(_ model: WishModel) {
+        Task {
+            let isCompleted = !model.isCompleted
+            _ = try? UpdateWishIntent.perform((
+                context: context,
+                id: model.id,
+                title: nil,
+                notes: nil,
+                dueDate: nil,
+                isCompleted: isCompleted,
+                priority: nil
+            ))
         }
     }
 


### PR DESCRIPTION
## Summary
- enable swipe actions for wishes to toggle completion status

## Testing
- `pre-commit run --files Wishle/Sources/Management/WishListView.swift` *(fails: HTTP 403 from github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68693248861883209704c82a55a2b46b