### PR TITLE
Move chat session logic into intents

### DIFF
--- a/Wishle/Sources/Chat/ChatSession.swift
+++ b/Wishle/Sources/Chat/ChatSession.swift
@@ -1,0 +1,10 @@
+import FoundationModels
+
+enum ChatSession {
+    static var session = LanguageModelSession(
+        instructions: """
+        You are Wishle, a helpful assistant who helps the user craft a wish through conversation.
+        Ask questions and refine details until the user confirms they are satisfied.
+        """
+    )
+}

--- a/Wishle/Sources/Chat/Intents/SendChatMessageIntent.swift
+++ b/Wishle/Sources/Chat/Intents/SendChatMessageIntent.swift
@@ -1,0 +1,21 @@
+import AppIntents
+import FoundationModels
+
+struct SendChatMessageIntent: AppIntent, IntentPerformer {
+    typealias Input = String
+    typealias Output = String
+
+    @Parameter(title: "Message")
+    private var text: String
+
+    nonisolated static let title: LocalizedStringResource = "Send Chat Message"
+
+    static func perform(_ input: Input) async throws -> Output {
+        let reply = try await ChatSession.session.respond(to: input)
+        return reply.content
+    }
+
+    func perform() async throws -> some ReturnsValue<String> {
+        .result(value: try await Self.perform(text))
+    }
+}

--- a/Wishle/Sources/Chat/Intents/SummarizeChatIntent.swift
+++ b/Wishle/Sources/Chat/Intents/SummarizeChatIntent.swift
@@ -1,0 +1,26 @@
+import AppIntents
+import FoundationModels
+
+struct SummarizeChatIntent: AppIntent, IntentPerformer {
+    typealias Input = Void
+    typealias Output = Wish
+
+    nonisolated static let title: LocalizedStringResource = "Summarize Chat"
+
+    static func perform(_: Input) async throws -> Output {
+        let result = try await ChatSession.session.respond(
+            to: "Summarize our conversation as a wish.",
+            generating: WishDraft.self
+        )
+        return .init(
+            title: result.content.title,
+            notes: result.content.notes,
+            priority: result.content.priority
+        )
+    }
+
+    func perform() async throws -> some ReturnsValue<String> {
+        let wish = try await Self.perform(())
+        return .result(value: wish.title)
+    }
+}

--- a/Wishle/Sources/Chat/WishDraft.swift
+++ b/Wishle/Sources/Chat/WishDraft.swift
@@ -1,0 +1,20 @@
+//
+//  WishDraft.swift
+//  Wishle
+//
+//  Created by Codex on 2025/07/05.
+//
+
+import FoundationModels
+
+@Generable
+struct WishDraft: Decodable {
+    @Guide(description: "Title for the wish")
+    var title: String
+
+    @Guide(description: "Optional notes about the wish")
+    var notes: String?
+
+    @Guide(description: "0 for normal priority, 1 for high")
+    var priority: Int
+}


### PR DESCRIPTION
## Summary
- add a reusable `ChatSession` that keeps the `LanguageModelSession`
- implement `SendChatMessageIntent` and `SummarizeChatIntent`
- call the new intents from `ChatView`

## Testing
- `pre-commit run --files Wishle/Sources/Chat/ChatView.swift Wishle/Sources/Chat/ChatSession.swift Wishle/Sources/Chat/Intents/SendChatMessageIntent.swift Wishle/Sources/Chat/Intents/SummarizeChatIntent.swift Wishle/Sources/Chat/WishDraft.swift` *(fails: error 403 fetching SwiftLint)*

------
https://chatgpt.com/codex/tasks/task_e_68692f9efd4c8320a86e2e44320f380f