### PR TITLE
Add local notification manager

### DIFF
--- a/Wishle/Sources/Shared/Models/NotificationManager.swift
+++ b/Wishle/Sources/Shared/Models/NotificationManager.swift
@@ -1,0 +1,90 @@
+//
+//  NotificationManager.swift
+//  Wishle
+//
+//  Created by Codex on 2025/07/25.
+//
+
+import Foundation
+import SwiftData
+import UserNotifications
+
+@MainActor
+final class NotificationManager {
+    static let shared = NotificationManager()
+
+    private let center = UNUserNotificationCenter.current()
+    private let defaults = UserDefaults.standard
+
+    private init() {}
+
+    func requestAuthorization() async {
+        _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+    }
+
+    func scheduleDeadlineNotification(for model: WishModel, daysBefore: Int = 0) {
+        guard let dueDate = model.dueDate else {
+            return
+        }
+        guard let fireDate = Calendar.current.date(byAdding: .day, value: -daysBefore, to: dueDate),
+              fireDate > .now else {
+            return
+        }
+        let components = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: fireDate)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let content = UNMutableNotificationContent()
+        content.title = "Wish Due"
+        content.body = model.title
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: "wish-\(model.id)",
+            content: content,
+            trigger: trigger
+        )
+        center.add(request)
+    }
+
+    func removeDeadlineNotification(for id: String) {
+        center.removePendingNotificationRequests(withIdentifiers: ["wish-\(id)"])
+    }
+
+    func scheduleDailySuggestion(at hour: Int = 9, minute: Int = 0) {
+        var components = DateComponents()
+        components.hour = hour
+        components.minute = minute
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+        let content = UNMutableNotificationContent()
+        content.title = "Wishle Suggestion"
+        content.body = "Need inspiration? Tap to see a new wish idea."
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: "daily-suggestion",
+            content: content,
+            trigger: trigger
+        )
+        center.add(request)
+    }
+
+    func recordLaunch() {
+        defaults.set(Date(), forKey: "lastLaunchDate")
+    }
+
+    func scheduleLaunchBasedSuggestion() {
+        guard let lastLaunch = defaults.object(forKey: "lastLaunchDate") as? Date,
+              let fireDate = Calendar.current.date(byAdding: .day, value: 1, to: lastLaunch),
+              fireDate > .now else {
+            return
+        }
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: fireDate.timeIntervalSinceNow, repeats: false)
+        let content = UNMutableNotificationContent()
+        content.title = "Wishle Suggestion"
+        content.body = "It\'s time for a new suggestion!"
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: "launch-suggestion",
+            content: content,
+            trigger: trigger
+        )
+        center.add(request)
+    }
+}

--- a/Wishle/Sources/Shared/Models/NotificationManager.swift
+++ b/Wishle/Sources/Shared/Models/NotificationManager.swift
@@ -13,13 +13,12 @@ import UserNotifications
 final class NotificationManager {
     static let shared = NotificationManager()
 
-    private let center = UNUserNotificationCenter.current()
     private let defaults = UserDefaults.standard
 
     private init() {}
 
     func requestAuthorization() async {
-        _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+        _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
     }
 
     func scheduleDeadlineNotification(for model: WishModel, daysBefore: Int = 0) {
@@ -41,11 +40,11 @@ final class NotificationManager {
             content: content,
             trigger: trigger
         )
-        center.add(request)
+        UNUserNotificationCenter.current().add(request)
     }
 
     func removeDeadlineNotification(for id: String) {
-        center.removePendingNotificationRequests(withIdentifiers: ["wish-\(id)"])
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["wish-\(id)"])
     }
 
     func scheduleDailySuggestion(at hour: Int = 9, minute: Int = 0) {
@@ -62,7 +61,7 @@ final class NotificationManager {
             content: content,
             trigger: trigger
         )
-        center.add(request)
+        UNUserNotificationCenter.current().add(request)
     }
 
     func recordLaunch() {
@@ -85,6 +84,6 @@ final class NotificationManager {
             content: content,
             trigger: trigger
         )
-        center.add(request)
+        UNUserNotificationCenter.current().add(request)
     }
 }

--- a/Wishle/Sources/Wish/Intents/AddWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/AddWishIntent.swift
@@ -8,6 +8,7 @@
 import AppIntents
 import SwiftData
 import SwiftUtilities
+import UserNotifications
 
 struct AddWishIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, title: String, notes: String?, dueDate: Date?, priority: Int)
@@ -39,6 +40,7 @@ struct AddWishIntent: AppIntent, IntentPerformer {
         )
         context.insert(model)
         try context.save()
+        NotificationManager.shared.scheduleDeadlineNotification(for: model, daysBefore: 1)
         return model.wish
     }
 

--- a/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/DeleteWishIntent.swift
@@ -8,6 +8,7 @@
 import AppIntents
 import SwiftData
 import SwiftUtilities
+import UserNotifications
 
 struct DeleteWishIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, id: String)
@@ -30,6 +31,7 @@ struct DeleteWishIntent: AppIntent, IntentPerformer {
         }
         context.delete(model)
         try context.save()
+        NotificationManager.shared.removeDeadlineNotification(for: model.id)
     }
 
     func perform() throws -> some IntentResult {

--- a/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/UpdateWishIntent.swift
@@ -8,6 +8,7 @@
 import AppIntents
 import SwiftData
 import SwiftUtilities
+import UserNotifications
 
 struct UpdateWishIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, id: String, title: String?, notes: String?, dueDate: Date?, isCompleted: Bool?, priority: Int?)
@@ -60,6 +61,8 @@ struct UpdateWishIntent: AppIntent, IntentPerformer {
         }
         model.updatedAt = .now
         try context.save()
+        NotificationManager.shared.removeDeadlineNotification(for: model.id)
+        NotificationManager.shared.scheduleDeadlineNotification(for: model, daysBefore: 1)
     }
 
     func perform() throws -> some IntentResult {

--- a/Wishle/Sources/WishleApp.swift
+++ b/Wishle/Sources/WishleApp.swift
@@ -11,6 +11,7 @@ import SwiftUI
 @main
 struct WishleApp: App {
     @State private var subscriptionManager = SubscriptionManager.shared
+    @State private var notificationManager = NotificationManager.shared
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding: Bool = false
 
     var sharedModelContainer: ModelContainer {
@@ -43,6 +44,12 @@ struct WishleApp: App {
             }
             .task {
                 await subscriptionManager.load()
+            }
+            .task {
+                await notificationManager.requestAuthorization()
+                notificationManager.recordLaunch()
+                notificationManager.scheduleDailySuggestion()
+                notificationManager.scheduleLaunchBasedSuggestion()
             }
         }
         .modelContainer(sharedModelContainer)


### PR DESCRIPTION
## Summary
- enable push notifications for daily suggestions and upcoming deadlines
- track last launch to send suggestions 24 hours later
- schedule/cleanup reminder notifications when modifying wishes

## Testing
- `swiftlint --fix --format --strict` *(fails: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_686938db8c848320af1d6b99bdbcb51e