### PR TITLE
Add complete and delete context menu actions

### DIFF
--- a/Wishle/Resources/Localizable.xcstrings
+++ b/Wishle/Resources/Localizable.xcstrings
@@ -422,10 +422,24 @@
       }
     },
     "Mark Complete" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了にする"
+          }
+        }
+      }
     },
     "Mark Incomplete" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未完了にする"
+          }
+        }
+      }
     },
     "Message" : {
 

--- a/Wishle/Sources/Management/WishListView.swift
+++ b/Wishle/Sources/Management/WishListView.swift
@@ -91,6 +91,12 @@ struct WishListView: View {
                             Button("Edit") {
                                 editingWish = model
                             }
+                            Button(model.isCompleted ? "Mark Incomplete" : "Mark Complete") {
+                                toggleCompletion(model)
+                            }
+                            Button("Delete", role: .destructive) {
+                                deleteWish(model)
+                            }
                         }
                         .swipeActions(edge: .leading) {
                             Button {
@@ -141,6 +147,15 @@ struct WishListView: View {
                     id: model.id
                 ))
             }
+        }
+    }
+
+    private func deleteWish(_ model: WishModel) {
+        Task {
+            _ = try? DeleteWishIntent.perform((
+                context: context,
+                id: model.id
+            ))
         }
     }
 


### PR DESCRIPTION
## Summary
- add `Mark Complete/Mark Incomplete` and `Delete` to the Wish list context menu
- localize `Mark Complete` and `Mark Incomplete` strings in Japanese

## Testing
- `swiftlint`

------
https://chatgpt.com/codex/tasks/task_e_68693de0e7d08320bf9cdb35ad8833f7