### PR TITLE
Refactor prompt language handling

### DIFF
--- a/Wishle/Sources/Chat/Intents/SendChatMessageIntent.swift
+++ b/Wishle/Sources/Chat/Intents/SendChatMessageIntent.swift
@@ -1,6 +1,7 @@
 import AppIntents
 import FoundationModels
 import SwiftUtilities
+import Foundation
 
 struct SendChatMessageIntent: AppIntent, IntentPerformer {
     typealias Input = String
@@ -12,8 +13,7 @@ struct SendChatMessageIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = "Send Chat Message"
 
     static func perform(_ input: Input) async throws -> Output {
-        let language = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
-        let prompt = "Respond in the user's device language: \(language). \(input)"
+        let prompt = PromptHelper.localized(input)
         let reply = try await ChatSession.session.respond(to: prompt)
         return reply.content
     }

--- a/Wishle/Sources/Chat/Intents/SummarizeChatIntent.swift
+++ b/Wishle/Sources/Chat/Intents/SummarizeChatIntent.swift
@@ -1,6 +1,7 @@
 import AppIntents
 import FoundationModels
 import SwiftUtilities
+import Foundation
 
 struct SummarizeChatIntent: AppIntent, IntentPerformer {
     typealias Input = Void
@@ -9,8 +10,7 @@ struct SummarizeChatIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = "Summarize Chat"
 
     static func perform(_: Input) async throws -> Output {
-        let language = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
-        let prompt = "Respond in the user's device language: \(language). Summarize our conversation as a wish."
+        let prompt = PromptHelper.localized("Summarize our conversation as a wish.")
         let result = try await ChatSession.session.respond(
             to: prompt,
             generating: WishDraft.self

--- a/Wishle/Sources/Shared/Extensions/Locale+DeviceLanguage.swift
+++ b/Wishle/Sources/Shared/Extensions/Locale+DeviceLanguage.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Locale {
+    /// The identifier for the user's current device language.
+    static var deviceLanguageIdentifier: String {
+        current.language.languageCode?.identifier ?? current.identifier
+    }
+}
+
+/// Utility for generating prompts that follow the user's device language.
+enum PromptHelper {
+    static func localized(_ text: String) -> String {
+        "Respond in the user's device language: \(Locale.deviceLanguageIdentifier). \(text)"
+    }
+}
+

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRandomIntent.swift
@@ -9,6 +9,7 @@ import AppIntents
 import FoundationModels
 import SwiftData
 import SwiftUtilities
+import Foundation
 
 @Generable
 private struct RandomWishSuggestion: Decodable {
@@ -30,9 +31,8 @@ struct SuggestWishFromRandomIntent: AppIntent, IntentPerformer {
             let wish = try FetchRandomWishIntent.perform(input)
             samples.append(wish)
         }
-        let language = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
         let promptList = samples.map { "- \($0.title)" }.joined(separator: "\n")
-        let prompt = "Respond in the user's device language: \(language). Suggest a new wish based on these wishes:\n\(promptList)"
+        let prompt = PromptHelper.localized("Suggest a new wish based on these wishes:\n\(promptList)")
         let session = LanguageModelSession()
         let response = try await session.respond(
             to: prompt,

--- a/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishFromRecentIntent.swift
@@ -9,6 +9,7 @@ import AppIntents
 import FoundationModels
 import SwiftData
 import SwiftUtilities
+import Foundation
 
 @Generable
 private struct RecentWishSuggestion: Decodable {
@@ -31,9 +32,8 @@ struct SuggestWishFromRecentIntent: AppIntent, IntentPerformer {
         descriptor.fetchLimit = 5
         let models = try input.fetch(descriptor)
         let recent = models.map(\.wish)
-        let language = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
         let promptList = recent.map { "- \($0.title)" }.joined(separator: "\n")
-        let prompt = "Respond in the user's device language: \(language). Suggest a new wish based on these recent wishes:\n\(promptList)"
+        let prompt = PromptHelper.localized("Suggest a new wish based on these recent wishes:\n\(promptList)")
         let session = LanguageModelSession()
         let response = try await session.respond(
             to: prompt,

--- a/Wishle/Sources/Wish/Intents/SuggestWishIntent.swift
+++ b/Wishle/Sources/Wish/Intents/SuggestWishIntent.swift
@@ -9,6 +9,9 @@ import AppIntents
 import FoundationModels
 import SwiftUtilities
 
+// Provides Locale.deviceLanguageIdentifier and PromptHelper
+import Foundation
+
 @Generable
 private struct WishSuggestion: Decodable {
     @Guide(description: "Title for the suggested wish")
@@ -41,10 +44,9 @@ struct SuggestWishIntent: AppIntent, IntentPerformer {
     }
 
     static func perform(_ input: Input) async throws -> Wish {
-        let language = Locale.current.language.languageCode?.identifier ?? Locale.current.identifier
         let prompt = promptTemplate
             .replacingOccurrences(of: "{{context}}", with: input)
-            .replacingOccurrences(of: "{{language}}", with: language)
+            .replacingOccurrences(of: "{{language}}", with: Locale.deviceLanguageIdentifier)
         let session = LanguageModelSession()
         do {
             let response = try await session.respond(


### PR DESCRIPTION
## Summary
- centralize language prefix logic in `PromptHelper`
- update Chat and Wish intents to use the shared helper

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `pre-commit` *(fails: GitHub access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6869403682cc8320ba6b7fdac85d1135