### PR TITLE
Improve chat response with foundation model

### DIFF
--- a/Wishle/Resources/Localizable.xcstrings
+++ b/Wishle/Resources/Localizable.xcstrings
@@ -636,6 +636,7 @@
       }
     },
     "Shall I create \"%@\"?" : {
+      "comment" : "Prompt to confirm wish creation",
       "localizations" : {
         "ja" : {
           "stringUnit" : {

--- a/Wishle/Sources/Chat/ChatClassifier.swift
+++ b/Wishle/Sources/Chat/ChatClassifier.swift
@@ -1,0 +1,50 @@
+//
+//  ChatClassifier.swift
+//  Wishle
+//
+//  Created by Codex on 2025/07/08.
+//  Copyright © 2025 Hiromu Nakano. All rights reserved.
+//
+
+import FoundationModels
+
+enum ChatClassifier {
+    enum Action {
+        case confirm
+        case cancel
+        case complete
+        case other
+    }
+
+    @Generable
+    private struct IntentResult: Decodable {
+        @Guide(description: "One of confirm, cancel, complete, or other")
+        var intent: String
+    }
+
+    static func classify(_ text: String) async throws -> Action {
+        let prompt = PromptHelper.localized(
+            """
+            Determine whether the following user message confirms creating a wish,
+            cancels it, indicates the conversation is complete, or is unrelated.
+            Respond only with a JSON object like:
+            {\"intent\": \"<confirm|cancel|complete|other>\"}
+            Message: \(text)
+            """
+        )
+        let result = try await ChatSession.session.respond(
+            to: prompt,
+            generating: IntentResult.self
+        )
+        switch result.content.intent.lowercased() {
+        case "confirm":
+            return .confirm
+        case "cancel":
+            return .cancel
+        case "complete":
+            return .complete
+        default:
+            return .other
+        }
+    }
+}

--- a/Wishle/Sources/Chat/ChatClassifier.swift
+++ b/Wishle/Sources/Chat/ChatClassifier.swift
@@ -17,7 +17,7 @@ enum ChatClassifier {
     }
 
     @Generable
-    private struct IntentResult: Decodable {
+    struct IntentResult: Decodable {
         @Guide(description: "One of confirm, cancel, complete, or other")
         var intent: String
     }

--- a/Wishle/Sources/Chat/ChatView.swift
+++ b/Wishle/Sources/Chat/ChatView.swift
@@ -120,23 +120,21 @@ struct ChatView: View {
             isSending = true
             do {
                 let responseText: String
+                let action = try? await ChatClassifier.classify(trimmed)
                 if pendingWish != nil {
-                    if trimmed.lowercased().contains("yes") ||
-                        trimmed.lowercased().contains("add") {
+                    switch action {
+                    case .confirm?:
                         isPresentingAddSheet = true
                         responseText = String(localized: "Opening the form.")
-                    } else if trimmed.lowercased().contains("no") ||
-                                trimmed.lowercased().contains("cancel") {
+                    case .cancel?:
                         responseText = String(
                             localized: "Okay, let me know if you change your mind."
                         )
                         pendingWish = nil
-                    } else {
+                    default:
                         responseText = try await SendChatMessageIntent.perform(trimmed)
                     }
-                } else if trimmed.lowercased().contains("ok") ||
-                            trimmed.lowercased().contains("looks good") ||
-                            trimmed.lowercased().contains("done") {
+                } else if action == .complete {
                     if let wish = try? await SummarizeChatIntent.perform(()) {
                         pendingWish = wish
                         let format = NSLocalizedString(


### PR DESCRIPTION
## Summary
- integrate `ChatClassifier` using FoundationModels for message intent detection
- update chat workflow to use classification results

## Testing
- `swiftlint` *(fails: cannot execute binary file)*
- `xcodebuild -version` *(fails: command not found)*
- `swift test` *(fails: no Package.swift found)*

------
https://chatgpt.com/codex/tasks/task_e_68694ab2d2e8832084b7bc873d7bb503