### PR TITLE
Fix chat intent classification session

### DIFF
--- a/Wishle/Sources/Chat/ChatClassifier.swift
+++ b/Wishle/Sources/Chat/ChatClassifier.swift
@@ -32,7 +32,8 @@ enum ChatClassifier {
             Message: \(text)
             """
         )
-        let result = try await ChatSession.session.respond(
+        let session = LanguageModelSession()
+        let result = try await session.respond(
             to: prompt,
             generating: IntentResult.self
         )


### PR DESCRIPTION
## Summary
- ensure `ChatClassifier` uses a fresh `LanguageModelSession`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `pre-commit run --files Wishle/Sources/Chat/ChatClassifier.swift` *(fails: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68695671f0b08320a5f23ae7f960210a